### PR TITLE
[관리자] 게시글 관리 페이지 만들기

### DIFF
--- a/src/main/resources/templates/layouts/layout-footer.th.xml
+++ b/src/main/resources/templates/layouts/layout-footer.th.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <thlogic>
-    <attr sel="#footer-link" th:href="@{https://github.com/djkeh/fastcampus-project-board-admin}" th:text="'게시판 어드민 프로젝트 GitHub'" />
+    <attr sel="#footer-link" th:href="@{https://github.com/y2gon2/fastcampus-project-board-admin}" th:text="'게시판 관리자 프로젝트 GitHub'" />
     <attr sel="#fastcampus-link" th:href="@{https://fastcampus.co.kr/}" th:text="'FastCampus'" />
 </thlogic>

--- a/src/main/resources/templates/management/article-comments.html
+++ b/src/main/resources/templates/management/article-comments.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
     <title>Title</title>

--- a/src/main/resources/templates/management/articles.html
+++ b/src/main/resources/templates/management/articles.html
@@ -1,10 +1,86 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
+<html lang="ko">
+<head id="layout-head">
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>게시글 관리 페이지</title>
+    <link rel="stylesheet" href="/js/plugins/datatables-bs4/css/dataTables.bootstrap4.min.css">
+    <link rel="stylesheet" href="/js/plugins/datatables-responsive/css/responsive.bootstrap4.min.css">
+    <link rel="stylesheet" href="/js/plugins/datatables-buttons/css/buttons.bootstrap4.min.css">
 </head>
-<body>
+<body class="hold-transition sidebar-mini">
+<div class="wrapper">
+    <header id="layout-header">헤더 삽입부</header>
+    <aside id="layout-left-aside">왼쪽 사이드 바 삽입부</aside>
 
-</body>
-</html>
+    <!-- Main content -->
+    <main id="layout-main">
+        <table id="main-table" class="table table-bordered table-striped">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>제목</th>
+                <th>작성자</th>
+                <th>작성일시</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td>1</td>
+                <td>새 글</td>
+                <td>Uno</td>
+                <td><time datetime="2022-01-01T00:00:00">2022-01-01 00:00:00</time></td>
+            </tr>
+            <tr>
+                <td>2</td>
+                <td>아무글</td>
+                <td>Uno</td>
+                <td><time datetime="2022-01-02T00:00:00">2022-01-02 00:00:00</time></td>
+            </tr>
+            <tr>
+                <td>3</td>
+                <td>스프링 부트 블로그 정리</td>
+                <td>Uno</td>
+                <td><time datetime="2022-01-03T00:00:00">2022-01-03 00:00:00</time></td>
+            </tr>
+            </tbody>
+            <tfoot>
+            <tr>
+                <th>ID</th>
+                <th>제목</th>
+                <th>작성자</th>
+                <th>작성일시</th>
+            </tr>
+            </tfoot>
+        </table>
+    </main>
+    <!-- /.content -->
+
+    <aside id="layout-right-aside">오른쪽 사이드 바 삽입부</aside>
+    <footer id="layout-footer">푸터 삽입부</footer>
+</div>
+
+<!--/* REQUIRED SCRIPTS */-->
+<script id="layout-scripts">/* 공통 스크립트 삽입부 */</script>
+
+<!--/* 페이지 전용 스크립트 */-->
+<script src="/js/plugins/datatables/jquery.dataTables.min.js"></script>
+<script src="/js/plugins/datatables-bs4/js/dataTables.bootstrap4.min.js"></script>
+<script src="/js/plugins/datatables-responsive/js/dataTables.responsive.min.js"></script>
+<script src="/js/plugins/datatables-responsive/js/responsive.bootstrap4.min.js"></script>
+<script src="/js/plugins/datatables-buttons/js/dataTables.buttons.min.js"></script>
+<script src="/js/plugins/datatables-buttons/js/buttons.bootstrap4.min.js"></script>
+<script src="/js/plugins/jszip/jszip.min.js"></script>
+<script src="/js/plugins/pdfmake/pdfmake.min.js"></script>
+<script src="/js/plugins/pdfmake/vfs_fonts.js"></script>
+<script src="/js/plugins/datatables-buttons/js/buttons.html5.min.js"></script>
+<script src="/js/plugins/datatables-buttons/js/buttons.print.min.js"></script>
+<script src="/js/plugins/datatables-buttons/js/buttons.colVis.min.js"></script>
+<script>
+    $(function () {
+        $("#main-table").DataTable({
+            "responsive": true, "lengthChange": false, "autoWidth": false,
+            "buttons": ["copy", "csv", "excel", "pdf", "print", "colvis"],
+            "pageLength": 10
+        }).buttons().container().appendTo('#main-table_wrapper .col-md-6:eq(0)'); // main-table_wrapper ID는 플러그인에 의해 자동 생성됨
+    });
+</script>

--- a/src/main/resources/templates/management/articles.th.xml
+++ b/src/main/resources/templates/management/articles.th.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
+    <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
+    <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
+    <attr sel="#layout-main" th:replace="layouts/layout-main-table :: common_main_table('게시글 관리', (~{::#main-table} ?: ~{}))" />
+    <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
+    <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
+    <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+</thlogic>

--- a/src/main/resources/templates/management/user-accounts.html
+++ b/src/main/resources/templates/management/user-accounts.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
     <title>Title</title>


### PR DESCRIPTION
Thymeleaf decouple logic 을 적용하여 HTML + JS code 파일과 thymeleaf code 파일을 사용하여 페이지를 구현함.

articles.html
 - 해당 페이지에서 사용할 css 파일 링크 정보를 layout-header (html + th.xml) 에 전달될 수 있도록 명시함.
 - main cotent part 에서 table 내 각 요소 정보에 대해서 정적 표현도 가능하고, 이를 thymeleaf 에서 가져가서 layout-main-table 에서도 구현 가능하도록 함
 - 해당 페이지 구현 전용 script 입력 및 JS code 입력

articles.th.xml
 - 이미 구현해놓은 layout part 에 article.html 의 해당 id 를 matching 하여 필요한 위치에  요청 layout 을 가져올 수 있게 할 뿐만 아니라, articles.html 내 data (title, link, main-table) 을 해당 layout 에서 받아서 구현할 수 있도록  fragment 구현


- 일부 사소한 수정 사항 추가 반영

This closes #16 