### PR TITLE
테이블명 변경: user_account -> admin_account

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/domain/AdminAccount.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/domain/AdminAccount.java
@@ -21,7 +21,7 @@ import java.util.Set;
         @Index(columnList = "createdBy")
 })
 @Entity
-public class UserAccount extends AuditingFields {
+public class AdminAccount extends AuditingFields {
     @Id @Column(length = 50) private String userId;
 
     @Setter @Column(nullable = false) private String userPassword;
@@ -36,9 +36,9 @@ public class UserAccount extends AuditingFields {
     @Setter @Column(length = 100) private String nickname;
     @Setter private String memo;
 
-    protected UserAccount() {}
+    protected AdminAccount() {}
 
-    private UserAccount(
+    private AdminAccount(
             String userId,
             String userPassword,
             Set<RoleType> roleTypes,
@@ -58,7 +58,7 @@ public class UserAccount extends AuditingFields {
     }
 
     // 인증 정보가 필요 없는 경우
-    public static UserAccount of(
+    public static AdminAccount of(
             String userId,
             String userPassword,
             Set<RoleType> roleTypes,
@@ -66,7 +66,7 @@ public class UserAccount extends AuditingFields {
             String nickname,
             String memo
     ) {
-        return UserAccount.of(
+        return AdminAccount.of(
                 userId,
                 userPassword,
                 roleTypes,
@@ -78,7 +78,7 @@ public class UserAccount extends AuditingFields {
     }
 
     // 인증 정보가 필요한 경우
-    public static UserAccount of(
+    public static AdminAccount of(
             String userId,
             String userPassword,
             Set<RoleType> roleTypes,
@@ -87,7 +87,7 @@ public class UserAccount extends AuditingFields {
             String memo,
             String createdBy
     ) {
-        return new UserAccount(
+        return new AdminAccount(
                 userId,
                 userPassword,
                 roleTypes,
@@ -114,7 +114,7 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        UserAccount that = (UserAccount) o;
+        AdminAccount that = (AdminAccount) o;
         return Objects.equals(this.getUserId(), that.getUserId());  // 직접 field 조회에서 getter 사용으로 변경. proxy 객체 직접 접근시 발생하는 문제 해결 ?
     }
 

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
@@ -1,0 +1,93 @@
+package com.fastcampus.projectboardadmin.dto;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTeyps,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+    public static AdminAccountDto of(
+            String userId,
+            String userPassword,
+            Set<RoleType> roleTypes,
+            String email,
+            String nickname,
+            String memo
+    ) {
+        return AdminAccountDto.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    public static AdminAccountDto of(
+            String userId,
+            String userPassword,
+            Set<RoleType> roleTypes,
+            String email,
+            String nickname,
+            String memo,
+            LocalDateTime createdAt,
+            String createdBy,
+            LocalDateTime modifiedAt,
+            String modifiedBy
+    ) {
+        return new AdminAccountDto(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo,
+                createdAt,
+                createdBy,
+                modifiedAt,
+                modifiedBy);
+    }
+
+    public static AdminAccountDto from(AdminAccount entity) {
+        return new AdminAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public AdminAccount toEntity() {
+        return AdminAccount.of(
+                userId,
+                userPassword,
+                roleTeyps,
+                email,
+                nickname,
+                memo
+        );
+    }
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleCommentDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleCommentDto.java
@@ -1,5 +1,7 @@
 package com.fastcampus.projectboardadmin.dto;
 
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+
 import java.time.LocalDateTime;
 
 public record ArticleCommentDto(

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleDto.java
@@ -1,7 +1,5 @@
 package com.fastcampus.projectboardadmin.dto;
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
-
 import java.time.LocalDateTime;
 import java.util.Set;
 

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
@@ -1,18 +1,9 @@
 package com.fastcampus.projectboardadmin.dto;
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
-import com.fastcampus.projectboardadmin.domain.constant.RoleType;
-
 import java.time.LocalDateTime;
-import java.util.Set;
 
-/**
- * DTO for {@link com.fastcampus.projectboardadmin.domain.UserAccount}
- */
 public record UserAccountDto(
         String userId,
-        String userPassword,
-        Set<RoleType> roleTeyps,
         String email,
         String nickname,
         String memo,
@@ -23,74 +14,25 @@ public record UserAccountDto(
 ) {
     public static UserAccountDto of(
             String userId,
-            String userPassword,
-            Set<RoleType> roleTypes,
             String email,
             String nickname,
             String memo
     ) {
-        return UserAccountDto.of(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo,
-                null,
-                null,
-                null,
-                null
+        return new UserAccountDto(
+                userId, email, nickname, memo, null, null, null, null
         );
     }
 
     public static UserAccountDto of(
             String userId,
-            String userPassword,
-            Set<RoleType> roleTypes,
             String email,
             String nickname,
             String memo,
             LocalDateTime createdAt,
             String createdBy,
             LocalDateTime modifiedAt,
-            String modifiedBy
-    ) {
-        return new UserAccountDto(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo,
-                createdAt,
-                createdBy,
-                modifiedAt,
-                modifiedBy);
+            String modifiedBy) {
+        return new UserAccountDto(userId, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
-    public static UserAccountDto from(UserAccount entity) {
-        return new UserAccountDto(
-                entity.getUserId(),
-                entity.getUserPassword(),
-                entity.getRoleTypes(),
-                entity.getEmail(),
-                entity.getNickname(),
-                entity.getMemo(),
-                entity.getCreatedAt(),
-                entity.getCreatedBy(),
-                entity.getModifiedAt(),
-                entity.getModifiedBy()
-                );
-    }
-
-    public UserAccount toEntity() {
-        return UserAccount.of(
-                userId,
-                userPassword,
-                roleTeyps,
-                email,
-                nickname,
-                memo
-        );
-    }
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
@@ -1,7 +1,7 @@
 package com.fastcampus.projectboardadmin.dto.security;
 
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
-import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -67,7 +67,7 @@ public record BoardAdminPrincipal(
     }
 
     // UserAccountDto -> BoardPrincipal 을 만들어야 할 경우
-    public static BoardAdminPrincipal from(UserAccountDto dto) {
+    public static BoardAdminPrincipal from(AdminAccountDto dto) {
         return BoardAdminPrincipal.of(
                 dto.userId(),
                 dto.userPassword(),
@@ -79,8 +79,8 @@ public record BoardAdminPrincipal(
     }
 
     // BoardPrincipal -> Dto
-    public UserAccountDto toDto() {
-        return UserAccountDto.of(
+    public AdminAccountDto toDto() {
+        return AdminAccountDto.of(
                 username,
                 password,
                 authorities.stream()

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
@@ -1,0 +1,9 @@
+package com.fastcampus.projectboardadmin.repository;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminAccountRepository extends JpaRepository<AdminAccount, String> {
+
+}
+

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
@@ -1,9 +1,0 @@
-package com.fastcampus.projectboardadmin.repository;
-
-import com.fastcampus.projectboardadmin.domain.UserAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
-
-}
-

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 -- 테스트 계정
 -- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
-insert into user_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+insert into admin_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
                                                                                                                                            ('uno', '{noop}asdf1234', 'ADMIN', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno'),
                                                                                                                                            ('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'uno', now(), 'uno'),
                                                                                                                                            ('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'uno', now(), 'uno'),

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -110,8 +110,6 @@ class ArticleCommentManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
-                Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",
                 "test memo"

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -128,8 +128,6 @@ class ArticleManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
           "unoTest",
-          "pw",
-          Set.of(RoleType.ADMIN),
           "uno-test@email.com",
           "uno-test",
           "test memo"

--- a/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
@@ -1,12 +1,11 @@
 package com.fastcampus.projectboardadmin.repository;
 
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.convert.DataSizeUnit;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -14,7 +13,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-import javax.swing.text.html.Option;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -33,11 +31,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest // slice test 로 모든 Spring Context 내 필요한 Bean Configuration 만 읽어옴. 때문에 test 용 Jpa configuration 을 별도로 생성하여 이를 사용해야 함.
 class JpaRepositoryTest {
 
-    private final UserAccountRepository userAccountRepository;
+    private final AdminAccountRepository adminAccountRepository;
 
 
-    public JpaRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
-        this.userAccountRepository = userAccountRepository;
+    public JpaRepositoryTest(@Autowired AdminAccountRepository adminAccountRepository) {
+        this.adminAccountRepository = adminAccountRepository;
     }
 
     @DisplayName("회원정보 Select Test")
@@ -47,7 +45,7 @@ class JpaRepositoryTest {
 
 
         // When
-        Optional<UserAccount> userAccouts = userAccountRepository.findById("uno");
+        Optional<AdminAccount> userAccouts = adminAccountRepository.findById("uno");
 
         // Then
         assertThat(userAccouts)
@@ -58,8 +56,8 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccount_whenInserting_thenWorkFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = UserAccount.of(
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = AdminAccount.of(
                 "test_id",
                 "pw",
                 Set.of(RoleType.DEVELOPER),
@@ -69,10 +67,10 @@ class JpaRepositoryTest {
         );
 
         // When
-        userAccountRepository.save(userAccount);
+        adminAccountRepository.save(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count())
+        assertThat(adminAccountRepository.count())
                 .isEqualTo(previousCount + 1);
     }
 
@@ -80,10 +78,10 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccountAndRoleType_whenInserting_thenWorksFine() {
         // Given
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
-        userAccount.addRoleType(RoleType.DEVELOPER);
-        userAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
-        userAccount.removeRoleType(RoleType.ADMIN);
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
+        adminAccount.addRoleType(RoleType.DEVELOPER);
+        adminAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
+        adminAccount.removeRoleType(RoleType.ADMIN);
 
         // When
         // 여기에서 save 요청은 기존에 존재하는 data 의 update 가 발생되어야 한다.
@@ -93,7 +91,7 @@ class JpaRepositoryTest {
         // UserAccount updatedAccount = userAccountRepository.save(userAccount);
         // 이렇게 강제적으로 바로 flush 를 하는 method 를 사용해야  update query 가 발생함을 확인할 수 있다. 
         // (test 끝난 후 내부적으로 별도의 rollback transaction 을 실행 시킴)
-        UserAccount updatedAccount = userAccountRepository.saveAndFlush(userAccount);
+        AdminAccount updatedAccount = adminAccountRepository.saveAndFlush(adminAccount);
 
         // Then
         assertThat(updatedAccount)
@@ -105,14 +103,14 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccount_whenDeleting_thenWorkFine() {
         // Given
-        long previousUserCount = userAccountRepository.count();
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
+        long previousUserCount = adminAccountRepository.count();
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
 
         // When
-        userAccountRepository.delete(userAccount);
+        adminAccountRepository.delete(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count())
+        assertThat(adminAccountRepository.count())
                 .isEqualTo(previousUserCount - 1);
     }
 

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -174,8 +174,6 @@ class ArticleCommentManagementServiceTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
-                Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",
                 "test memo"

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -196,8 +196,6 @@ class ArticleManagementServiceTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
           "unoTest",
-          "pw",
-          Set.of(RoleType.ADMIN),
           "uno-test@email.com",
           "uno-test",
           "test memo"


### PR DESCRIPTION
초기 설정에서 관리자 계정 정보 table 명을 [게시판 프로젝트] 에서 받아오는 일반 회원 계정 table 과 같아, 혼용되어 구현되고 있었다. 이를 분리하여 [게시판 프로젝트 - 일반 회원 계정] 은 그대로 UserAccount 사용하고, 관리자 계정을 AdminAccount 로 수정 및 상황에 맞게 객체 사용을 정리하였다. 아울러, 일반회원 정보에서 받을 수 없는 RoleType 정보와  보안 상 일반 계정에서 받을 필요가 없는 password 정보는 UserAccountDto 에서 제거하였다. UserAccount Entity 는 우선 삭제 하였다.

This closes #40 