### PR TITLE
[관리자] 회원 관리 페이지 기능 Test 정의

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/domain/AdminAccount.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/domain/AdminAccount.java
@@ -21,7 +21,7 @@ import java.util.Set;
         @Index(columnList = "createdBy")
 })
 @Entity
-public class UserAccount extends AuditingFields {
+public class AdminAccount extends AuditingFields {
     @Id @Column(length = 50) private String userId;
 
     @Setter @Column(nullable = false) private String userPassword;
@@ -36,9 +36,9 @@ public class UserAccount extends AuditingFields {
     @Setter @Column(length = 100) private String nickname;
     @Setter private String memo;
 
-    protected UserAccount() {}
+    protected AdminAccount() {}
 
-    private UserAccount(
+    private AdminAccount(
             String userId,
             String userPassword,
             Set<RoleType> roleTypes,
@@ -58,7 +58,7 @@ public class UserAccount extends AuditingFields {
     }
 
     // 인증 정보가 필요 없는 경우
-    public static UserAccount of(
+    public static AdminAccount of(
             String userId,
             String userPassword,
             Set<RoleType> roleTypes,
@@ -66,7 +66,7 @@ public class UserAccount extends AuditingFields {
             String nickname,
             String memo
     ) {
-        return UserAccount.of(
+        return AdminAccount.of(
                 userId,
                 userPassword,
                 roleTypes,
@@ -78,7 +78,7 @@ public class UserAccount extends AuditingFields {
     }
 
     // 인증 정보가 필요한 경우
-    public static UserAccount of(
+    public static AdminAccount of(
             String userId,
             String userPassword,
             Set<RoleType> roleTypes,
@@ -87,7 +87,7 @@ public class UserAccount extends AuditingFields {
             String memo,
             String createdBy
     ) {
-        return new UserAccount(
+        return new AdminAccount(
                 userId,
                 userPassword,
                 roleTypes,
@@ -114,7 +114,7 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        UserAccount that = (UserAccount) o;
+        AdminAccount that = (AdminAccount) o;
         return Objects.equals(this.getUserId(), that.getUserId());  // 직접 field 조회에서 getter 사용으로 변경. proxy 객체 직접 접근시 발생하는 문제 해결 ?
     }
 

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
@@ -1,0 +1,93 @@
+package com.fastcampus.projectboardadmin.dto;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTeyps,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+    public static AdminAccountDto of(
+            String userId,
+            String userPassword,
+            Set<RoleType> roleTypes,
+            String email,
+            String nickname,
+            String memo
+    ) {
+        return AdminAccountDto.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    public static AdminAccountDto of(
+            String userId,
+            String userPassword,
+            Set<RoleType> roleTypes,
+            String email,
+            String nickname,
+            String memo,
+            LocalDateTime createdAt,
+            String createdBy,
+            LocalDateTime modifiedAt,
+            String modifiedBy
+    ) {
+        return new AdminAccountDto(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo,
+                createdAt,
+                createdBy,
+                modifiedAt,
+                modifiedBy);
+    }
+
+    public static AdminAccountDto from(AdminAccount entity) {
+        return new AdminAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public AdminAccount toEntity() {
+        return AdminAccount.of(
+                userId,
+                userPassword,
+                roleTeyps,
+                email,
+                nickname,
+                memo
+        );
+    }
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleCommentDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleCommentDto.java
@@ -1,5 +1,7 @@
 package com.fastcampus.projectboardadmin.dto;
 
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+
 import java.time.LocalDateTime;
 
 public record ArticleCommentDto(

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleDto.java
@@ -1,7 +1,5 @@
 package com.fastcampus.projectboardadmin.dto;
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
-
 import java.time.LocalDateTime;
 import java.util.Set;
 

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
@@ -1,18 +1,9 @@
 package com.fastcampus.projectboardadmin.dto;
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
-import com.fastcampus.projectboardadmin.domain.constant.RoleType;
-
 import java.time.LocalDateTime;
-import java.util.Set;
 
-/**
- * DTO for {@link com.fastcampus.projectboardadmin.domain.UserAccount}
- */
 public record UserAccountDto(
         String userId,
-        String userPassword,
-        Set<RoleType> roleTeyps,
         String email,
         String nickname,
         String memo,
@@ -23,74 +14,25 @@ public record UserAccountDto(
 ) {
     public static UserAccountDto of(
             String userId,
-            String userPassword,
-            Set<RoleType> roleTypes,
             String email,
             String nickname,
             String memo
     ) {
-        return UserAccountDto.of(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo,
-                null,
-                null,
-                null,
-                null
+        return new UserAccountDto(
+                userId, email, nickname, memo, null, null, null, null
         );
     }
 
     public static UserAccountDto of(
             String userId,
-            String userPassword,
-            Set<RoleType> roleTypes,
             String email,
             String nickname,
             String memo,
             LocalDateTime createdAt,
             String createdBy,
             LocalDateTime modifiedAt,
-            String modifiedBy
-    ) {
-        return new UserAccountDto(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo,
-                createdAt,
-                createdBy,
-                modifiedAt,
-                modifiedBy);
+            String modifiedBy) {
+        return new UserAccountDto(userId, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
-    public static UserAccountDto from(UserAccount entity) {
-        return new UserAccountDto(
-                entity.getUserId(),
-                entity.getUserPassword(),
-                entity.getRoleTypes(),
-                entity.getEmail(),
-                entity.getNickname(),
-                entity.getMemo(),
-                entity.getCreatedAt(),
-                entity.getCreatedBy(),
-                entity.getModifiedAt(),
-                entity.getModifiedBy()
-                );
-    }
-
-    public UserAccount toEntity() {
-        return UserAccount.of(
-                userId,
-                userPassword,
-                roleTeyps,
-                email,
-                nickname,
-                memo
-        );
-    }
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/response/UserAccountClientResponse.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/response/UserAccountClientResponse.java
@@ -1,0 +1,34 @@
+package com.fastcampus.projectboardadmin.dto.response;
+
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record UserAccountClientResponse(
+        @JsonProperty("_embedded") Embedded embedded,
+        @JsonProperty("page") Page page
+) {
+    public static UserAccountClientResponse empty() {
+        return new UserAccountClientResponse(
+                new Embedded(List.of()),
+                new Page(1, 0, 1, 0)
+        );
+    }
+
+    public static UserAccountClientResponse of(List<UserAccountDto> useraAccounts) {
+        return new UserAccountClientResponse(
+                new Embedded(useraAccounts),
+                new Page(useraAccounts.size(), useraAccounts.size(), 1, 0)
+        );
+    }
+
+    public record Embedded(List<UserAccountDto> userAccounts) {}
+
+    public record Page(
+       int size,
+       long totalElements,
+       int totalPages,
+       int number
+    ) {}
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
@@ -1,7 +1,7 @@
 package com.fastcampus.projectboardadmin.dto.security;
 
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
-import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -67,7 +67,7 @@ public record BoardAdminPrincipal(
     }
 
     // UserAccountDto -> BoardPrincipal 을 만들어야 할 경우
-    public static BoardAdminPrincipal from(UserAccountDto dto) {
+    public static BoardAdminPrincipal from(AdminAccountDto dto) {
         return BoardAdminPrincipal.of(
                 dto.userId(),
                 dto.userPassword(),
@@ -79,8 +79,8 @@ public record BoardAdminPrincipal(
     }
 
     // BoardPrincipal -> Dto
-    public UserAccountDto toDto() {
-        return UserAccountDto.of(
+    public AdminAccountDto toDto() {
+        return AdminAccountDto.of(
                 username,
                 password,
                 authorities.stream()

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
@@ -1,0 +1,9 @@
+package com.fastcampus.projectboardadmin.repository;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminAccountRepository extends JpaRepository<AdminAccount, String> {
+
+}
+

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
@@ -1,9 +1,0 @@
-package com.fastcampus.projectboardadmin.repository;
-
-import com.fastcampus.projectboardadmin.domain.UserAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
-
-}
-

--- a/src/main/java/com/fastcampus/projectboardadmin/service/UserAccountManagementService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/UserAccountManagementService.java
@@ -1,0 +1,18 @@
+package com.fastcampus.projectboardadmin.service;
+
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class UserAccountManagementService {
+
+    public List<UserAccountDto> getUsers() { return List.of(); }
+
+    public UserAccountDto getUser(String uerId) { return null; }
+
+    public void deleteUser(String userId) {  }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 -- 테스트 계정
 -- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
-insert into user_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+insert into admin_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
                                                                                                                                            ('uno', '{noop}asdf1234', 'ADMIN', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno'),
                                                                                                                                            ('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'uno', now(), 'uno'),
                                                                                                                                            ('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'uno', now(), 'uno'),

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -110,8 +110,6 @@ class ArticleCommentManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
-                Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",
                 "test memo"

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -128,8 +128,6 @@ class ArticleManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
           "unoTest",
-          "pw",
-          Set.of(RoleType.ADMIN),
           "uno-test@email.com",
           "uno-test",
           "test memo"

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -1,7 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
-import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import com.fastcampus.projectboardadmin.dto.ArticleDto;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
 import com.fastcampus.projectboardadmin.service.ArticleManagementService;
@@ -16,7 +15,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
 
 import static org.mockito.BDDMockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
@@ -1,14 +1,21 @@
 package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.service.UserAccountManagementService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -20,6 +27,8 @@ class UserAccountManagementControllerTest {
 
     private final MockMvc mvc;
 
+    @MockBean private UserAccountManagementService userAccountManagementService;
+
     public UserAccountManagementControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
     }
@@ -28,11 +37,58 @@ class UserAccountManagementControllerTest {
     @Test
     void givenNothing_whenRequestingUserAccountManagementView_thenReturnsUserAccountManagementView() throws Exception {
         // Given
+        given(userAccountManagementService.getUsers()).willReturn(List.of());
 
         // When & Then
         mvc.perform(get("/management/user-accounts"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("management/user-accounts"));    }
+                .andExpect(view().name("management/user-accounts"))
+                .andExpect(model().attribute("userAccounts", List.of()));
 
+        then(userAccountManagementService).should().getUsers();
+    }
+
+    @DisplayName("[View][GET] 1명의 회원 정보 - 정상 호출")
+    @Test
+    void givenUserId_whenRequestingUserAccount_thenReturnsUserAccount() throws Exception {
+        // Given
+        String userId = "uno";
+        UserAccountDto userAccountDto = createAccountDto(userId, "Uno");
+        given(userAccountManagementService.getUser(userId)).willReturn(userAccountDto);
+
+        // When & Then
+        mvc.perform(get("/mangement/user-accounts/" + userId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.userId").value(userId))  // 그런데 json 에 userId 는 없는데???
+                .andExpect(jsonPath("$.nickname").value(userAccountDto.nickname()));
+        then(userAccountManagementService).should().getUser(userId);
+    }
+
+    @DisplayName("[View][POST] 회원 정보 삭제 - 정상 호출")
+    @Test
+    void givenUserId_whenRequestingDeletion_thenRedirectsToUserAccountManagement() throws Exception {
+        // Given
+        String userId = "uno";
+        willDoNothing().given(userAccountManagementService).deleteUser(userId);
+
+        // When & Then
+        mvc.perform(post("/management/user-accounts/" + userId))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/management/user-accounts"))
+                .andExpect(redirectedUrl("management/user-accounts"));
+
+        then(userAccountManagementService).should().deleteUser(userId);
+    }
+
+    // ---------------- Fixture for Test ------------------------
+    private UserAccountDto createAccountDto(String userId, String nickname) {
+        return UserAccountDto.of(
+                userId,
+                "uno-test@email.com",
+                nickname,
+                "test memo"
+        );
+    }
 }

--- a/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
@@ -38,9 +38,9 @@ class JpaRepositoryTest {
         this.adminAccountRepository = adminAccountRepository;
     }
 
-    @DisplayName("회원정보 Select Test")
+    @DisplayName("관리자 정보 Select Test")
     @Test
-    void givenUserAccounts_whenSelecting_thenWorkFine() {
+    void givenAdminAccounts_whenSelecting_thenWorkFine() {
         // Given
 
 
@@ -52,9 +52,9 @@ class JpaRepositoryTest {
                 .isNotNull();
     }
 
-    @DisplayName("회원 정보 Insert Test")
+    @DisplayName("관리자 정보 Insert Test")
     @Test
-    void givenUserAccount_whenInserting_thenWorkFine() {
+    void givenAdminAccount_whenInserting_thenWorkFine() {
         // Given
         long previousCount = adminAccountRepository.count();
         AdminAccount adminAccount = AdminAccount.of(
@@ -74,9 +74,9 @@ class JpaRepositoryTest {
                 .isEqualTo(previousCount + 1);
     }
 
-    @DisplayName("회원 정보 Update Test")
+    @DisplayName("관리자 정보 Update Test")
     @Test
-    void givenUserAccountAndRoleType_whenInserting_thenWorksFine() {
+    void givenAdminAccountAndRoleType_whenInserting_thenWorksFine() {
         // Given
         AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
         adminAccount.addRoleType(RoleType.DEVELOPER);
@@ -99,9 +99,9 @@ class JpaRepositoryTest {
                 .hasFieldOrPropertyWithValue("roleTypes", Set.of(RoleType.DEVELOPER, RoleType.USER));
     }
 
-    @DisplayName("회원정보 Delete Test")
+    @DisplayName("관리자 정보 Delete Test")
     @Test
-    void givenUserAccount_whenDeleting_thenWorkFine() {
+    void givenAdminAccount_whenDeleting_thenWorkFine() {
         // Given
         long previousUserCount = adminAccountRepository.count();
         AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");

--- a/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
@@ -1,12 +1,11 @@
 package com.fastcampus.projectboardadmin.repository;
 
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.convert.DataSizeUnit;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -14,7 +13,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-import javax.swing.text.html.Option;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -33,11 +31,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest // slice test 로 모든 Spring Context 내 필요한 Bean Configuration 만 읽어옴. 때문에 test 용 Jpa configuration 을 별도로 생성하여 이를 사용해야 함.
 class JpaRepositoryTest {
 
-    private final UserAccountRepository userAccountRepository;
+    private final AdminAccountRepository adminAccountRepository;
 
 
-    public JpaRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
-        this.userAccountRepository = userAccountRepository;
+    public JpaRepositoryTest(@Autowired AdminAccountRepository adminAccountRepository) {
+        this.adminAccountRepository = adminAccountRepository;
     }
 
     @DisplayName("회원정보 Select Test")
@@ -47,7 +45,7 @@ class JpaRepositoryTest {
 
 
         // When
-        Optional<UserAccount> userAccouts = userAccountRepository.findById("uno");
+        Optional<AdminAccount> userAccouts = adminAccountRepository.findById("uno");
 
         // Then
         assertThat(userAccouts)
@@ -58,8 +56,8 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccount_whenInserting_thenWorkFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = UserAccount.of(
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = AdminAccount.of(
                 "test_id",
                 "pw",
                 Set.of(RoleType.DEVELOPER),
@@ -69,10 +67,10 @@ class JpaRepositoryTest {
         );
 
         // When
-        userAccountRepository.save(userAccount);
+        adminAccountRepository.save(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count())
+        assertThat(adminAccountRepository.count())
                 .isEqualTo(previousCount + 1);
     }
 
@@ -80,10 +78,10 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccountAndRoleType_whenInserting_thenWorksFine() {
         // Given
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
-        userAccount.addRoleType(RoleType.DEVELOPER);
-        userAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
-        userAccount.removeRoleType(RoleType.ADMIN);
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
+        adminAccount.addRoleType(RoleType.DEVELOPER);
+        adminAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
+        adminAccount.removeRoleType(RoleType.ADMIN);
 
         // When
         // 여기에서 save 요청은 기존에 존재하는 data 의 update 가 발생되어야 한다.
@@ -93,7 +91,7 @@ class JpaRepositoryTest {
         // UserAccount updatedAccount = userAccountRepository.save(userAccount);
         // 이렇게 강제적으로 바로 flush 를 하는 method 를 사용해야  update query 가 발생함을 확인할 수 있다. 
         // (test 끝난 후 내부적으로 별도의 rollback transaction 을 실행 시킴)
-        UserAccount updatedAccount = userAccountRepository.saveAndFlush(userAccount);
+        AdminAccount updatedAccount = adminAccountRepository.saveAndFlush(adminAccount);
 
         // Then
         assertThat(updatedAccount)
@@ -105,14 +103,14 @@ class JpaRepositoryTest {
     @Test
     void givenUserAccount_whenDeleting_thenWorkFine() {
         // Given
-        long previousUserCount = userAccountRepository.count();
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
+        long previousUserCount = adminAccountRepository.count();
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
 
         // When
-        userAccountRepository.delete(userAccount);
+        adminAccountRepository.delete(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count())
+        assertThat(adminAccountRepository.count())
                 .isEqualTo(previousUserCount - 1);
     }
 

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -174,8 +174,6 @@ class ArticleCommentManagementServiceTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
-                Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",
                 "test memo"

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -85,6 +85,8 @@ class ArticleCommentManagementServiceTest {
             this.mapper = mapper;
         }
 
+        // TODO: 게시글과 달리 화면 요청 api 로 확인했을 때 회원 정보를 한방에 모아서 보내주는 건 없었는데...
+        //       CRUD 요청에서 findAll 로 하면 다 가져올수 있는건지... 모르겠다..
         @DisplayName("댓글 목록 API를 호출하면, 댓글들을 가져온다")
         @Test
         void givenNothing_whenCallingArticleCommentsApi_thenReturnsArticleComments() throws Exception {

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -196,8 +196,6 @@ class ArticleManagementServiceTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
           "unoTest",
-          "pw",
-          Set.of(RoleType.ADMIN),
           "uno-test@email.com",
           "uno-test",
           "test memo"

--- a/src/test/java/com/fastcampus/projectboardadmin/service/UserAccountManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/UserAccountManagementServiceTest.java
@@ -1,0 +1,168 @@
+package com.fastcampus.projectboardadmin.service;
+
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.properties.ProjectProperty;
+import com.fastcampus.projectboardadmin.dto.response.UserAccountClientResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+
+@DisplayName("Business Logic - 일반 회원 관리")
+@ActiveProfiles("test")
+class UserAccountManagementServiceTest {
+
+    // 1. 실제 API server 통신 상태 test
+    @Disabled("실제 API 호출 결과 확인을 위한 test 이므로 logic test 상황에서는 비활성화")
+    @DisplayName("실제 API 호출 Test")
+    @SpringBootTest
+    @Nested
+    class RealApiTest {
+
+        private final UserAccountManagementService sut;
+
+        public RealApiTest(UserAccountManagementService sut) {
+            this.sut = sut;
+        }
+
+        @DisplayName("일반 회원 정보 API 를 호출하면, 회원 정보를 가저온다.")
+        @Test
+        void givenNothing_whenCallUserAccountsApi_thenReturnsUserAccounts() {
+            // Given
+
+            // When
+            List<UserAccountDto> result = sut.getUsers();
+
+            // Then
+            System.out.println(result.stream().findFirst());
+            assertThat(result).isNotNull();
+        }
+    }
+
+    // 2. Mocking server 를 사용하는 test
+    @DisplayName("API Mocking test")
+    @EnableConfigurationProperties(ProjectProperty.class)
+    @AutoConfigureWebClient(registerRestTemplate = true)
+    @RestClientTest(UserAccountManagementService.class)
+    @Nested
+    class RestTemplateTest {
+
+        private  final UserAccountManagementService sut;
+        private final ProjectProperty projectProperty;
+        private final MockRestServiceServer server;
+        private final ObjectMapper mapper;
+
+        @Autowired
+        public RestTemplateTest(
+                UserAccountManagementService sut,
+                ProjectProperty projectProperty,
+                MockRestServiceServer server,
+                ObjectMapper mapper
+        ) {
+            this.sut = sut;
+            this.projectProperty = projectProperty;
+            this.server = server;
+            this.mapper = mapper;
+        }
+
+        // TODO: 게시글과 달리 화면 요청 api 로 확인했을 때 회원 정보를 한방에 모아서 보내주는 건 없었는데...
+        //       CRUD 요청에서 findAll 로 하면 다 가져올수 있는건지... 모르겠다..
+        @DisplayName("일반 회원 정보 목록 API 를 호출하면, 전체 일반 회원 정보를 가져온다.")
+        @Test
+        void givenNothing_whenCallingUserAccountsApi_thenReturnsUserAccounts() throws Exception {
+            // Given
+            UserAccountDto expectedUser = createUserAccountDto("uno", "Uno");
+            UserAccountClientResponse expectedResponse = UserAccountClientResponse.of(List.of(expectedUser));
+
+            server
+                    .expect(requestTo(projectProperty.board().url() + "/management/user-accounts"))
+                    .andRespond(withSuccess(
+                            mapper.writeValueAsString(expectedResponse),
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            // When
+            List<UserAccountDto> result = sut.getUsers();
+
+            // Then
+            assertThat(result).first()
+                    .hasFieldOrPropertyWithValue("userId", expectedUser.userId())
+                    .hasFieldOrPropertyWithValue("nickname", expectedUser.nickname());
+
+            server.verify();
+        }
+
+        @DisplayName("회원 ID와 함께 회원 API를 호출하면, 회원을 가져온다.")
+        @Test
+        void givenUserAccountId_whenCallingUserAccountApi_thenReturnsUserAccount() throws Exception {
+            // Given
+            String userId = "uno";
+            UserAccountDto expectedUser = createUserAccountDto(userId, "Uno");
+
+            server
+                    .expect(requestTo(projectProperty.board().url() + "/management/user-accounts/" + userId))
+                    .andRespond(withSuccess(
+                            mapper.writeValueAsString(expectedUser),
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            // When
+            UserAccountDto result = sut.getUser(userId);
+
+            // Then
+            assertThat(result)
+                    .hasFieldOrPropertyWithValue("userId", expectedUser.userId())
+                    .hasFieldOrPropertyWithValue("nickname", expectedUser.nickname());
+
+            server.verify();
+        }
+
+        @DisplayName("회원 ID와 함께 삭제 API를 호출하면, 회원 정보를 삭제한다.")
+        @Test
+        void givenUserAccountId_whenCallingDeleteUserAccountApi_thenReturnsUserAccount() throws Exception {
+            // Given
+            String userId = "uno";
+            server
+                    .expect(requestTo(projectProperty.board().url() + "/management/user-accounts/" + userId))
+                    .andExpect(method(HttpMethod.DELETE))
+                    .andRespond(withSuccess());
+
+            // When
+            sut.deleteUser(userId);
+
+            // Then
+            server.verify();
+        }
+    }
+
+    // -------------- Fixture for Test ----------------
+    private UserAccountDto createUserAccountDto(String userId, String nickname) {
+        return UserAccountDto.of(
+                userId,
+                "uno-test@email.com",
+                nickname,
+                "test memo"
+        );
+    }
+
+}


### PR DESCRIPTION
댓글, 게시글과 동일하게 business logic 을 배제하고, 우선 예상 기능에 대한 동작을 test 구현

AdminAccount 와 UserAccount 가 혼용되어 있는 상태를 분리.

This closes #23 