### PR TITLE
기본 에러 페이지 구현 

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/config/SecurityConfig.java
@@ -1,12 +1,50 @@
 package com.fastcampus.projectboardadmin.config;
 
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.security.BoardAdminPrincipal;
+import com.fastcampus.projectboardadmin.dto.security.KakaoOAuth2Response;
+import com.fastcampus.projectboardadmin.service.AdminAccountService;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 
+import java.util.Set;
+import java.util.UUID;
+
 import static org.springframework.security.config.Customizer.withDefaults;
+
+// Spring Security 인증 과정 (by ChatGPT)
+// 질문
+// application 실행 중  .formLogin(Customizer.withDefaults()) method 실행 요청 입력된다면,
+// UserDetailsService 객체 정보를 가지고 인증 작업을 진행하는건가?
+//
+// ChatGPT
+// 네, 맞습니다. .formLogin(Customizer.withDefaults())는 폼 기반 인증을 활성화합니다.
+// 그리고 기본적으로, 폼 기반 인증은 사용자가 제공한 사용자 이름(username)과 비밀번호(password)를 이용하여 인증을 진행합니다.
+//
+// Spring Security의 기본 구성에 따르면, UserDetailsService는 사용자 이름으로 UserDetails 객체를 로드하는 역할을 합니다.
+// UserDetails 객체는 사용자의 사용자 이름, 비밀번호, 권한, 계정 상태 정보(계정 만료, 잠김 상태 등)를 포함합니다.
+//
+// 인증 과정은 다음과 같이 진행됩니다:
+//
+// 사용자가 로그인 폼에서 사용자 이름과 비밀번호를 입력하고 제출합니다.
+// Spring Security는 UserDetailsService를 사용하여 입력된 사용자 이름과 일치하는 UserDetails 객체를 검색합니다.
+// UserDetails 객체에서 가져온 비밀번호와 사용자가 폼에서 입력한 비밀번호를 비교합니다.
+// 비밀번호가 일치하면 인증은 성공적으로 완료됩니다. 그렇지 않으면 인증 실패 예외가 발생합니다.
+// 추가로, UserDetails 객체는 계정의 상태 정보 (예: 계정이 잠겼는지, 비밀번호가 만료되었는지 등)도 제공하므로,
+// 해당 상태 정보를 기반으로 추가적인 검사가 수행될 수 있습니다.
+// 따라서 UserDetailsService는 폼 기반 인증의 핵심 구성 요소 중 하나입니다.
 
 @Configuration
 public class SecurityConfig {
@@ -14,12 +52,80 @@ public class SecurityConfig {
     // secruity 에 태워서 security 에 관리하에 두고 인증과 권한 체크 진행
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        String [] rolesAboveManager = {
+                RoleType.ADMIN.name(),
+                RoleType.DEVELOPER.name(),
+                RoleType.MANAGER.name()
+        };
+
         return http
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll()) // 현재 모든 요청을 통과 시킴
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .mvcMatchers(HttpMethod.POST, "/**").hasAnyRole(rolesAboveManager) // mvcMatchers() 는 spring 3.0 에서 requestMatchers 로 변경 됨.
+                        .mvcMatchers(HttpMethod.DELETE, "/**").hasAnyRole(rolesAboveManager)
+                        .anyRequest().authenticated() // permitAll() 에서 인증 필요로 변경
+                )
                 .formLogin(withDefaults()) // 기본값을 내부적으로 설정. 따라서 method chaining 을 위한 and() 가 필요 없어짐.
                 .logout(logout -> logout.logoutSuccessUrl("/"))
                 .oauth2Login(withDefaults())
                 .build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(AdminAccountService adminAccountService) {
+        return username -> adminAccountService
+                .searchUser(username)
+                .map(BoardAdminPrincipal::from)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 계정을 찾을수 없습니다. - username : " + username));
+    }
+
+    /**
+     * <p>
+     * OAuth 2.0 을 이용한 인증 정보를 처리
+     * 카카오 인증 방식 선택
+     *
+     * @param adminAccountService 게시판 서비스의 사용자 계정을 다루는 service logic
+     * @param passwordEncoder 패스워드 암호와 도구
+     * @return {@link OAuth2UserService} OAuth2 인증 사용자 정보를 읽어들이고 처리하는 service instance 반환
+     */
+    @Bean
+    public OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService(
+            AdminAccountService adminAccountService,
+            PasswordEncoder passwordEncoder
+    ) {
+        final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
+
+        return userRequest -> {
+            OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+            KakaoOAuth2Response kakaoResponse = KakaoOAuth2Response.from(oAuth2User.getAttributes());
+
+            String registrationId = userRequest.getClientRegistration().getRegistrationId();
+            String providerId = String.valueOf(kakaoResponse.id());
+            String username = registrationId + "_" + providerId;
+            String dummyPassword = passwordEncoder.encode("{bcrypt}" + UUID.randomUUID());
+            Set<RoleType> roleTypes = Set.of(RoleType.USER);
+
+            return adminAccountService.searchUser(username)
+                    .map(BoardAdminPrincipal::from)
+                    .orElseGet(() ->
+                            BoardAdminPrincipal.from(
+                                    adminAccountService.saveUser(
+                                            username,
+                                            dummyPassword,
+                                            roleTypes,
+                                            kakaoResponse.email(),
+                                            kakaoResponse.nickname(),
+                                            null
+                                    )
+                            )
+                    );
+        };
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }
 

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/AdminAccountController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/AdminAccountController.java
@@ -1,28 +1,67 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.dto.response.AdminAccountResponse;
+import com.fastcampus.projectboardadmin.service.AdminAccountService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/admin/members")
+import java.util.List;
+
+@RequiredArgsConstructor
 @Controller
 public class AdminAccountController {
 
-    @GetMapping
-    public String adminAccount (
-            @PageableDefault(
-                    size = 10,
-                    sort = "createdAt",
-                    direction = Sort.Direction.DESC
-            )Pageable pageable,
-            Model model
-            ) {
+    private final AdminAccountService adminAccountService;
+
+    @RequestMapping("/admin/members")
+    public String adminAccount (Model model) {
         return "admin/members";
     }
 
+    // 관리자 정보 view 에서는 JsGrid 를 사용하여
+    // Table 상태에서 특정 정보 (ex. email, 권한) 등을 수정할 수 있다.
+    // 이를 위해서 다른 view 들과 다른 REST 작업 method 가 필요하다.
+
+    // @ResponseBody (by chatGPT)
+    // @ResponseBody 어노테이션은 Spring MVC에서 사용되며, 컨트롤러의 메서드가 반환하는 값을
+    // HTTP 응답 본문(body)으로 직접 작성하도록 지시
+    //
+    // 기본적으로 Spring MVC의 컨트롤러 메서드는 뷰 이름(view name)을 반환합니다.
+    // 예를 들어, Thymeleaf, JSP, FreeMarker와 같은 뷰 템플릿을 사용하여 UI를 생성할 때
+    // 해당 뷰 이름에 따라 특정 템플릿이 선택되고 렌더링됩니다.
+    //
+    // 그러나 때로는 클라이언트에게 JSON, XML과 같은 형태의 데이터를 직접 반환해야 할 필요가 있습니다.
+    // 이러한 경우에 @ResponseBody를 사용하여 메서드가 반환하는 객체나 값이
+    // HTTP 응답 본문으로 직접 변환되도록 할 수 있습니다.
+    //
+    // Spring에서 @ResponseBody는 내부적으로 HttpMessageConverter를 사용하여 반환된 객체를
+    // HTTP 응답 본문으로 변환합니다. 예를 들어, Jackson 라이브러리가 classpath에 포함되어 있으면
+    // 반환된 객체는 기본적으로 JSON 형식으로 변환됩니다.
+    //
+    // 아래 코드에서 getMembers 메서드는 List<AdminAccountResponse>를 반환합니다.
+    // @ResponseBody 어노테이션 덕분에 이 리스트는 클라이언트에게 JSON 배열로 변환되어 반환됩니다.
+    //
+    // @RestController 어노테이션을 사용하여 컨트롤러를 선언하면, 해당 컨트롤러의 모든 메서드에 자동으로
+    // @ResponseBody가 적용됩니다. 따라서 이 경우 별도로 @ResponseBody를 메서드에 붙일 필요가 없습니다.
+    @ResponseBody
+    @GetMapping("/api/admin/members")
+    public List<AdminAccountResponse> getMembers() {
+        return List.of();
+//        return adminAccountService.users().stream()
+//                .map(AdminAccountResponse::from)
+//                .toList();
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT) // 응답 HttpStatus 를 특정 code 로 지정하기 위해 사용? (NO_CONTENT - 204 (delete 에 주로 사용), OK - 200 (default) CREATED - 200 (insert))
+    @ResponseBody
+    @DeleteMapping("/api/admin/members/{userId}")
+    public void delete(@PathVariable String userId) {
+//        adminAccountService.deleteUser(userId);
+    }
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementController.java
@@ -13,14 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class ArticleCommentManagementController {
 
     @GetMapping
-    public String articleComments(
-            @PageableDefault(
-                    size = 10,
-                    sort = "createdAt",
-                    direction = Sort.Direction.DESC
-            ) Pageable pageable,
-            Model model
-            ) {
+    public String articleComments(Model model) {
         return "management/article-comments";
     }
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
@@ -14,14 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class ArticleManagementController {
 
     @GetMapping
-    public String article(
-            @PageableDefault(
-                    size = 10,
-                    sort = "CreatedAt",
-                    direction = Sort.Direction.DESC
-            )Pageable pageable,
-            Model model
-    ) {
+    public String article(Model model) {
         return "management/articles";
     }
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementController.java
@@ -13,14 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class UserAccountManagementController {
 
     @GetMapping
-    public String userAccount(
-            @PageableDefault(
-                    size = 10,
-                    sort = "CreatedAt",
-                    direction = Sort.Direction.DESC
-            )Pageable pageable,
-            Model model
-            ) {
+    public String userAccount(Model model) {
         return "management/user-accounts";
     }
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/domain/AdminAccount.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/domain/AdminAccount.java
@@ -21,7 +21,7 @@ import java.util.Set;
         @Index(columnList = "createdBy")
 })
 @Entity
-public class UserAccount extends AuditingFields {
+public class AdminAccount extends AuditingFields {
     @Id @Column(length = 50) private String userId;
 
     @Setter @Column(nullable = false) private String userPassword;
@@ -36,9 +36,9 @@ public class UserAccount extends AuditingFields {
     @Setter @Column(length = 100) private String nickname;
     @Setter private String memo;
 
-    protected UserAccount() {}
+    protected AdminAccount() {}
 
-    private UserAccount(
+    private AdminAccount(
             String userId,
             String userPassword,
             Set<RoleType> roleTypes,
@@ -58,7 +58,7 @@ public class UserAccount extends AuditingFields {
     }
 
     // 인증 정보가 필요 없는 경우
-    public static UserAccount of(
+    public static AdminAccount of(
             String userId,
             String userPassword,
             Set<RoleType> roleTypes,
@@ -66,7 +66,7 @@ public class UserAccount extends AuditingFields {
             String nickname,
             String memo
     ) {
-        return UserAccount.of(
+        return AdminAccount.of(
                 userId,
                 userPassword,
                 roleTypes,
@@ -78,7 +78,7 @@ public class UserAccount extends AuditingFields {
     }
 
     // 인증 정보가 필요한 경우
-    public static UserAccount of(
+    public static AdminAccount of(
             String userId,
             String userPassword,
             Set<RoleType> roleTypes,
@@ -87,7 +87,7 @@ public class UserAccount extends AuditingFields {
             String memo,
             String createdBy
     ) {
-        return new UserAccount(
+        return new AdminAccount(
                 userId,
                 userPassword,
                 roleTypes,
@@ -114,7 +114,7 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        UserAccount that = (UserAccount) o;
+        AdminAccount that = (AdminAccount) o;
         return Objects.equals(this.getUserId(), that.getUserId());  // 직접 field 조회에서 getter 사용으로 변경. proxy 객체 직접 접근시 발생하는 문제 해결 ?
     }
 

--- a/src/main/java/com/fastcampus/projectboardadmin/domain/constant/RoleType.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/domain/constant/RoleType.java
@@ -5,13 +5,14 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum RoleType {
-    USER("ROLE_USER"), // ROLE : spring-security 에서 문자열로 권한 표현을 하는 규칙
-    MANAGER("ROLE_MANAGER"),
-    DEVELOPER("ROLE_DEVELOPER"),
-    ADMIN("ROLE_ADMIN")
+    USER("ROLE_USER", "사용자"), // ROLE : spring-security 에서 문자열로 권한 표현을 하는 규칙
+    MANAGER("ROLE_MANAGER", "운영자"),
+    DEVELOPER("ROLE_DEVELOPER", "개발자"),
+    ADMIN("ROLE_ADMIN", "관리자")
     ;
 
     @Getter private final String roleName;
+    @Getter private final String Description;
 
 }
 

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
@@ -1,0 +1,93 @@
+package com.fastcampus.projectboardadmin.dto;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public record AdminAccountDto(
+        String userId,
+        String userPassword,
+        Set<RoleType> roleTeyps,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+    public static AdminAccountDto of(
+            String userId,
+            String userPassword,
+            Set<RoleType> roleTypes,
+            String email,
+            String nickname,
+            String memo
+    ) {
+        return AdminAccountDto.of(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    public static AdminAccountDto of(
+            String userId,
+            String userPassword,
+            Set<RoleType> roleTypes,
+            String email,
+            String nickname,
+            String memo,
+            LocalDateTime createdAt,
+            String createdBy,
+            LocalDateTime modifiedAt,
+            String modifiedBy
+    ) {
+        return new AdminAccountDto(
+                userId,
+                userPassword,
+                roleTypes,
+                email,
+                nickname,
+                memo,
+                createdAt,
+                createdBy,
+                modifiedAt,
+                modifiedBy);
+    }
+
+    public static AdminAccountDto from(AdminAccount entity) {
+        return new AdminAccountDto(
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getRoleTypes(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public AdminAccount toEntity() {
+        return AdminAccount.of(
+                userId,
+                userPassword,
+                roleTeyps,
+                email,
+                nickname,
+                memo
+        );
+    }
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleCommentDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleCommentDto.java
@@ -1,0 +1,59 @@
+package com.fastcampus.projectboardadmin.dto;
+
+import java.time.LocalDateTime;
+
+public record ArticleCommentDto(
+        Long id,
+        Long articleId,
+        UserAccountDto userAccountDto,
+        Long parentCommentId,
+        String content,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+    public ArticleCommentDto of(
+            Long articleId,
+            UserAccountDto userAccountDto,
+            Long parentCommentId,
+            String content
+    ) {
+        return new ArticleCommentDto(
+                null,
+                articleId,
+                userAccountDto,
+                parentCommentId,
+                content,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    public static ArticleCommentDto of(
+            Long id,
+            Long articleId,
+            UserAccountDto userAccountDto,
+            Long parentCommentId,
+            String content,
+            LocalDateTime createdAt,
+            String createdBy,
+            LocalDateTime modifiedAt,
+            String modifiedBy
+    ) {
+        return new ArticleCommentDto(
+                id,
+                articleId,
+                userAccountDto,
+                parentCommentId,
+                content,
+                createdAt,
+                createdBy,
+                modifiedAt,
+                modifiedBy
+        );
+    }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleCommentDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleCommentDto.java
@@ -1,5 +1,7 @@
 package com.fastcampus.projectboardadmin.dto;
 
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+
 import java.time.LocalDateTime;
 
 public record ArticleCommentDto(

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/ArticleDto.java
@@ -1,7 +1,5 @@
 package com.fastcampus.projectboardadmin.dto;
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
-
 import java.time.LocalDateTime;
 import java.util.Set;
 

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/UserAccountDto.java
@@ -1,18 +1,9 @@
 package com.fastcampus.projectboardadmin.dto;
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
-import com.fastcampus.projectboardadmin.domain.constant.RoleType;
-
 import java.time.LocalDateTime;
-import java.util.Set;
 
-/**
- * DTO for {@link com.fastcampus.projectboardadmin.domain.UserAccount}
- */
 public record UserAccountDto(
         String userId,
-        String userPassword,
-        Set<RoleType> roleTeyps,
         String email,
         String nickname,
         String memo,
@@ -23,74 +14,25 @@ public record UserAccountDto(
 ) {
     public static UserAccountDto of(
             String userId,
-            String userPassword,
-            Set<RoleType> roleTypes,
             String email,
             String nickname,
             String memo
     ) {
-        return UserAccountDto.of(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo,
-                null,
-                null,
-                null,
-                null
+        return new UserAccountDto(
+                userId, email, nickname, memo, null, null, null, null
         );
     }
 
     public static UserAccountDto of(
             String userId,
-            String userPassword,
-            Set<RoleType> roleTypes,
             String email,
             String nickname,
             String memo,
             LocalDateTime createdAt,
             String createdBy,
             LocalDateTime modifiedAt,
-            String modifiedBy
-    ) {
-        return new UserAccountDto(
-                userId,
-                userPassword,
-                roleTypes,
-                email,
-                nickname,
-                memo,
-                createdAt,
-                createdBy,
-                modifiedAt,
-                modifiedBy);
+            String modifiedBy) {
+        return new UserAccountDto(userId, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
-    public static UserAccountDto from(UserAccount entity) {
-        return new UserAccountDto(
-                entity.getUserId(),
-                entity.getUserPassword(),
-                entity.getRoleTypes(),
-                entity.getEmail(),
-                entity.getNickname(),
-                entity.getMemo(),
-                entity.getCreatedAt(),
-                entity.getCreatedBy(),
-                entity.getModifiedAt(),
-                entity.getModifiedBy()
-                );
-    }
-
-    public UserAccount toEntity() {
-        return UserAccount.of(
-                userId,
-                userPassword,
-                roleTeyps,
-                email,
-                nickname,
-                memo
-        );
-    }
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/response/AdminAccountResponse.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/response/AdminAccountResponse.java
@@ -1,0 +1,51 @@
+package com.fastcampus.projectboardadmin.dto.response;
+
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
+
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+
+public record AdminAccountResponse(
+        String userId,
+        String roleTypes,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy
+) {
+    public static AdminAccountResponse of(
+            String userId,
+            String roleTypes,
+            String email,
+            String nickname,
+            String memo,
+            LocalDateTime createdAt,
+            String createdBy
+    ) {
+        return new AdminAccountResponse(
+                userId,
+                roleTypes,
+                email,
+                nickname,
+                memo,
+                createdAt,
+                createdBy
+        );
+    }
+
+    public static AdminAccountResponse from(AdminAccountDto dto) {
+        return AdminAccountResponse.of(
+                dto.userId(),
+                dto.roleTeyps().stream()
+                        .map(RoleType::getDescription)
+                        .collect(Collectors.joining(", ")),
+                dto.email(),
+                dto.nickname(),
+                dto.memo(),
+                dto.createdAt(),
+                dto.createdBy()
+        );
+    }
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/response/CommentClientResponse.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/response/CommentClientResponse.java
@@ -1,0 +1,35 @@
+package com.fastcampus.projectboardadmin.dto.response;
+
+import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record CommentClientResponse(
+    @JsonProperty("_embedded") Embedded enbedded,
+    @JsonProperty("page") Page page
+) {
+
+    public static CommentClientResponse empty() {
+        return new CommentClientResponse(
+                new Embedded(List.of()),
+                new Page(1, 0, 1, 0)
+        );
+    }
+
+    public static CommentClientResponse of(List<ArticleCommentDto> comments) {
+        return new CommentClientResponse(
+                new Embedded(comments),
+                new Page(comments.size(), comments.size(), 1, 0)
+        );
+    }
+
+    public record Embedded(List<ArticleCommentDto> comments) {}
+
+    public record Page(
+            int size,
+            long totalElements,
+            int totalPages,
+            int number
+    ) {}
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/response/UserAccountClientResponse.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/response/UserAccountClientResponse.java
@@ -1,0 +1,34 @@
+package com.fastcampus.projectboardadmin.dto.response;
+
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record UserAccountClientResponse(
+        @JsonProperty("_embedded") Embedded embedded,
+        @JsonProperty("page") Page page
+) {
+    public static UserAccountClientResponse empty() {
+        return new UserAccountClientResponse(
+                new Embedded(List.of()),
+                new Page(1, 0, 1, 0)
+        );
+    }
+
+    public static UserAccountClientResponse of(List<UserAccountDto> useraAccounts) {
+        return new UserAccountClientResponse(
+                new Embedded(useraAccounts),
+                new Page(useraAccounts.size(), useraAccounts.size(), 1, 0)
+        );
+    }
+
+    public record Embedded(List<UserAccountDto> userAccounts) {}
+
+    public record Page(
+       int size,
+       long totalElements,
+       int totalPages,
+       int number
+    ) {}
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
@@ -1,7 +1,7 @@
 package com.fastcampus.projectboardadmin.dto.security;
 
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
-import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -67,7 +67,7 @@ public record BoardAdminPrincipal(
     }
 
     // UserAccountDto -> BoardPrincipal 을 만들어야 할 경우
-    public static BoardAdminPrincipal from(UserAccountDto dto) {
+    public static BoardAdminPrincipal from(AdminAccountDto dto) {
         return BoardAdminPrincipal.of(
                 dto.userId(),
                 dto.userPassword(),
@@ -79,8 +79,8 @@ public record BoardAdminPrincipal(
     }
 
     // BoardPrincipal -> Dto
-    public UserAccountDto toDto() {
-        return UserAccountDto.of(
+    public AdminAccountDto toDto() {
+        return AdminAccountDto.of(
                 username,
                 password,
                 authorities.stream()

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/AdminAccountRepository.java
@@ -1,0 +1,9 @@
+package com.fastcampus.projectboardadmin.repository;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminAccountRepository extends JpaRepository<AdminAccount, String> {
+
+}
+

--- a/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/repository/UserAccountRepository.java
@@ -1,9 +1,0 @@
-package com.fastcampus.projectboardadmin.repository;
-
-import com.fastcampus.projectboardadmin.domain.UserAccount;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
-
-}
-

--- a/src/main/java/com/fastcampus/projectboardadmin/service/AdminAccountService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/AdminAccountService.java
@@ -1,0 +1,41 @@
+package com.fastcampus.projectboardadmin.service;
+
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
+import com.fastcampus.projectboardadmin.repository.AdminAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Service
+public class AdminAccountService {
+
+    private final AdminAccountRepository adminAccountRepository;
+
+    public Optional<AdminAccountDto> searchUser(String username) {
+        return Optional.empty();
+    }
+
+    public AdminAccountDto saveUser(
+            String username,
+            String password,
+            Set<RoleType> roleTypes,
+            String email,
+            String nickname,
+            String memo
+    ) {
+        return null;
+    }
+
+    public List<AdminAccountDto> users() {
+        return List.of();
+    }
+
+    public void deleteUser(String username) {
+
+    }
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementService.java
@@ -1,0 +1,18 @@
+package com.fastcampus.projectboardadmin.service;
+
+import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ArticleCommentManagementService {
+
+    public List<ArticleCommentDto> getArticleComments() { return List.of(); }
+
+    public ArticleCommentDto getArticleComment(Long articleCommentId) { return null; }
+
+    public void deleteArticleComment(Long articleCommentId) {}
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/service/UserAccountManagementService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/UserAccountManagementService.java
@@ -1,0 +1,18 @@
+package com.fastcampus.projectboardadmin.service;
+
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class UserAccountManagementService {
+
+    public List<UserAccountDto> getUsers() { return List.of(); }
+
+    public UserAccountDto getUser(String uerId) { return null; }
+
+    public void deleteUser(String userId) {  }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 -- 테스트 계정
 -- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅. 개선하는 것이 좋을 지 고민해 보자.
-insert into user_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
+insert into admin_account (user_id, user_password, role_types, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
                                                                                                                                            ('uno', '{noop}asdf1234', 'ADMIN', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno'),
                                                                                                                                            ('mark', '{noop}asdf1234', 'MANAGER', 'Mark', 'mark@mail.com', 'I am Mark.', now(), 'uno', now(), 'uno'),
                                                                                                                                            ('susan', '{noop}asdf1234', 'MANAGER,DEVELOPER', 'Susan', 'Susan@mail.com', 'I am Susan.', now(), 'uno', now(), 'uno'),

--- a/src/main/resources/templates/error/4xx.html
+++ b/src/main/resources/templates/error/4xx.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head id="layout-head">
+  <meta charset="UTF-8">
+  <title>4XX 에러</title>
+</head>
+<body class="hold-transition sidebar-mini">
+<div class="wrapper">
+  <header id="layout-header">헤더 삽입부</header>
+  <aside id="layout-left-aside">왼쪽 사이드 바 삽입부</aside>
+
+  <main class="content-wrapper">
+    <!-- Content Header (Page header) -->
+    <section class="content-header">
+      <div class="container-fluid">
+        <div class="row mb-2">
+          <div class="col-sm-6">
+            <h1 id="main-header-title" class="m-0">Error Page</h1>
+          </div>
+          <div class="col-sm-6">
+            <ol class="breadcrumb float-sm-right">
+              <li class="breadcrumb-item"><a id="breadcrumb-home">Home</a></li>
+              <li id="breadcrumb-current-page" class="breadcrumb-item active지">Error Page</li>
+            </ol>
+          </div>
+        </div>
+      </div><!-- /.container-fluid -->
+    </section>
+
+    <!-- Main content -->
+    <section class="content">
+      <div class="error-page">
+        <h2 id="error-status" class="headline text-warning">4XX</h2>
+
+        <div class="error-content">
+          <h3><i class="fas fa-exclamation-triangle text-warning"></i> Oops!</h3>
+
+          <p>
+            <span id="error-message">Something went wrong.</span>
+          </p>
+        </div>
+        <!-- /.error-content -->
+      </div>
+      <!-- /.error-page -->
+    </section>
+    <!-- /.content -->
+  </main>
+  <!-- /.content-wrapper -->
+
+  <aside id="layout-right-aside">오른쪽 사이드 바 삽입부</aside>
+  <footer id="layout-footer">푸터 삽입부</footer>
+</div>
+<!-- ./wrapper -->
+
+<!--/* REQUIRED SCRIPTS */-->
+<script id="layout-scripts">/* 공통 스크립트 삽입부 */</script>
+
+<!--/* 페이지 전용 스크립트 */-->
+</body>
+</html>

--- a/src/main/resources/templates/error/4xx.th.xml
+++ b/src/main/resources/templates/error/4xx.th.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
+    <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
+    <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
+    <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
+    <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
+    <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+
+    <attr sel="#main-header-title" th:text="'에러 페이지'" />
+    <attr sel="#breadcrumb-home" th:href="@{/}" th:text="'홈'" />
+    <attr sel="#breadcrumb-current-page" th:text="'에러 페이지'" />
+    <attr sel="#error-status" th:text="${#response.status}" />
+    <attr sel="#error-message" th:text="'잘못된 호출입니다.'" />
+</thlogic>

--- a/src/main/resources/templates/error/5xx.html
+++ b/src/main/resources/templates/error/5xx.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head id="layout-head">
+    <meta charset="UTF-8">
+    <title>5XX 에러</title>
+</head>
+<body class="hold-transition sidebar-mini">
+<div class="wrapper">
+    <header id="layout-header">헤더 삽입부</header>
+    <aside id="layout-left-aside">왼쪽 사이드 바 삽입부</aside>
+
+    <main class="content-wrapper">
+        <!-- Content Header (Page header) -->
+        <section class="content-header">
+            <div class="container-fluid">
+                <div class="row mb-2">
+                    <div class="col-sm-6">
+                        <h1 id="main-header-title" class="m-0">Error Page</h1>
+                    </div>
+                    <div class="col-sm-6">
+                        <ol class="breadcrumb float-sm-right">
+                            <li class="breadcrumb-item"><a id="breadcrumb-home">Home</a></li>
+                            <li id="breadcrumb-current-page" class="breadcrumb-item active지">Error Page</li>
+                        </ol>
+                    </div>
+                </div>
+            </div><!-- /.container-fluid -->
+        </section>
+
+        <!-- Main content -->
+        <section class="content">
+            <div class="error-page">
+                <h2 id="error-status" class="headline text-danger">5XX</h2>
+
+                <div class="error-content">
+                    <h3><i class="fas fa-exclamation-triangle text-danger"></i> Oops!</h3>
+
+                    <p>
+                        <span id="error-message">Something went wrong.</span>
+                    </p>
+                </div>
+                <!-- /.error-content -->
+            </div>
+            <!-- /.error-page -->
+        </section>
+        <!-- /.content -->
+    </main>
+    <!-- /.content-wrapper -->
+
+    <aside id="layout-right-aside">오른쪽 사이드 바 삽입부</aside>
+    <footer id="layout-footer">푸터 삽입부</footer>
+</div>
+<!-- ./wrapper -->
+
+<!--/* REQUIRED SCRIPTS */-->
+<script id="layout-scripts">/* 공통 스크립트 삽입부 */</script>
+
+<!--/* 페이지 전용 스크립트 */-->
+</body>
+</html>

--- a/src/main/resources/templates/error/5xx.th.xml
+++ b/src/main/resources/templates/error/5xx.th.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
+    <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
+    <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
+    <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
+    <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
+    <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+
+    <attr sel="#main-header-title" th:text="'에러 페이지'" />
+    <attr sel="#breadcrumb-home" th:href="@{/}" th:text="'홈'" />
+    <attr sel="#breadcrumb-current-page" th:text="'에러 페이지'" />
+    <attr sel="#error-status" th:text="${#response.status}" />
+    <attr sel="#error-message" th:text="'알 수 없는 에러가 발생했어요!'" />
+</thlogic>

--- a/src/test/java/com/fastcampus/projectboardadmin/config/TestSecurityConfig.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/config/TestSecurityConfig.java
@@ -1,0 +1,50 @@
+package com.fastcampus.projectboardadmin.config;
+
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
+import com.fastcampus.projectboardadmin.service.AdminAccountService;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@Import(SecurityConfig.class)
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @MockBean private AdminAccountService adminAccountService;
+
+    @BeforeTestMethod
+    public void securitySetup() {
+        given(adminAccountService.searchUser(anyString()))
+                .willReturn(Optional.of(createAdminAccountDto()));
+
+        // 가입용?
+        given(adminAccountService.saveUser(
+                anyString(),
+                anyString(),
+                anySet(),
+                anyString(),
+                anyString(),
+                anyString()
+        )).willReturn(createAdminAccountDto());
+    }
+
+    private AdminAccountDto createAdminAccountDto() {
+        return AdminAccountDto.of(
+          "unoTest",
+          "pw",
+          Set.of(RoleType.USER),
+          "e@mail.com",
+          "Uno",
+          "memeo"
+        );
+    }
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/AdminAccountControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/AdminAccountControllerTest.java
@@ -1,17 +1,38 @@
 package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
+import com.fastcampus.projectboardadmin.service.AdminAccountService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+// @Import(TestSecurityConfig.class) 적용시 문제점
+// test 에서 Spring Security 인증 과정을 매번 수행하지 않도록
+// 미리 계정을 생성하고 인증을 통과하는 작업을 완료해 놓은 TestSecurityConfig.class 를
+// import 하여 사용하였다.
+// 그런데 해당 test 의 대상이 곧 인증 대상이므로, AdminAccount가  두번 정의되는 문제가 발생한다.
+// (Error: Duplicate mock definition)
+// 따라서 실제 application class (SecurityConfig.class) 를 사용하고, 관련 인증 처리를 모두 해주어야 한다.
 @DisplayName("View Controller - Admin Account")
 @Import(SecurityConfig.class)
 @WebMvcTest(AdminAccountController.class)
@@ -19,13 +40,34 @@ class AdminAccountControllerTest {
 
     private final MockMvc mvc;
 
+    @MockBean private AdminAccountService adminAccountService;
+
     public AdminAccountControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
     }
 
+    // 앞에서 언급한대로 TestSecurtiyConfig.class import 를 쓸 수 없기 때문에 (Duplicate mock definition 발생)
+    // security 설정을 내부에서 진행
+    @BeforeTestMethod
+    public void securitySetup() {
+        given(adminAccountService.searchUser(anyString()))
+                .willReturn(Optional.of(createAdminAccountDto()));
+
+        // 가입용?
+        given(adminAccountService.saveUser(
+                anyString(),
+                anyString(),
+                anySet(),
+                anyString(),
+                anyString(),
+                anyString()
+        )).willReturn(createAdminAccountDto());
+    }
+
+    @WithMockUser(username = "tester", roles = "USER")
     @DisplayName("[View][GET] 관리자 계정 페이지 - 정상 호출")
     @Test
-    void givenNothing_whenRequestingAdminAccountView_thenWorksFine() throws Exception {
+    void givenAuthorizedUser_whenRequestingAdminMembersView_thenReturnsAdminMembersView() throws Exception {
         // Given
 
         // When & Then
@@ -33,5 +75,49 @@ class AdminAccountControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("admin/members"));
+    }
+
+    @WithMockUser(username = "tester", roles = "USER")
+    @DisplayName("[data][GET] 관리자 리스트 - 정상 호출")
+    @Test
+    void givenAuthorizedUser_whenRequestingAdmin_thenReturnsAdmin() throws Exception {
+        // Given
+        given(adminAccountService.users()).willReturn(List.of());
+
+        // When & Then
+        mvc.perform(get("/api/admin/members"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+        then(adminAccountService).should().users();
+    }
+
+    @WithMockUser(username = "tester", roles = "MANAGER")
+    @DisplayName("[data][DELETE] 관리자 정보 삭제 - 정상 호출")
+    @Test
+    void givenAuthorizedUser_whenDeletingAdminAccount_thenDeletesAdminAccount() throws Exception {
+        // Given
+        String username = "uno";
+        willDoNothing().given(adminAccountService).deleteUser(username);
+
+        // When & Then
+        mvc.perform(
+                delete("/api/admin/members/" + username)
+                        .with(csrf())
+        )
+                .andExpect(status().isNoContent());
+        then(adminAccountService).should().deleteUser(username);
+
+    }
+
+    // -------------------- Fixture for Test --------------------
+    private AdminAccountDto createAdminAccountDto() {
+        return AdminAccountDto.of(
+                "unoTest",
+                "pw",
+                Set.of(RoleType.USER),
+                "uno-test@email.com",
+                "uno-test",
+                "test memo"
+        );
     }
 }

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -1,15 +1,28 @@
 package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.service.ArticleCommentManagementService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View Controller - 댓글 관리")
@@ -19,6 +32,8 @@ class ArticleCommentManagementControllerTest {
 
     private final MockMvc mvc;
 
+    @MockBean private ArticleCommentManagementService articleCommentManagementService;
+
     public ArticleCommentManagementControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
     }
@@ -27,13 +42,80 @@ class ArticleCommentManagementControllerTest {
     @Test
     void givenNothing_whenRequestingArticleCommentsManagementView_thenReturnsArticleCommentsManagementView() throws Exception {
         // Given
+        given(articleCommentManagementService.getArticleComments()).willReturn(List.of());
 
         // When & Then
         mvc.perform(get("/management/article-comments"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("management/article-comments"));
+                .andExpect(view().name("management/article-comments"))
+                .andExpect(model().attribute("Comments", List.of()));
+
+        then(articleCommentManagementService).should().getArticleComments();
     }
 
+    @DisplayName("[view][GET] 댓글 1개 - 정상 호출")
+    @Test
+    void givenNothing_whenRequestingArticleComment_thenReturnsArticleComment() throws Exception {
+        // Given
+        Long commentId = 1L;
+        ArticleCommentDto articleCommentDto = createArticleCommentDto("댓글");
+        given(articleCommentManagementService.getArticleComment(commentId)).willReturn(articleCommentDto);
+
+        // When & Then
+        mvc.perform(get("/management/article-comments/" + commentId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(commentId))
+                .andExpect(jsonPath("$.content").value(articleCommentDto.content()))
+                .andExpect(jsonPath("$.userAccount.nickname").value(articleCommentDto.userAccountDto().nickname()));
+
+        then(articleCommentManagementService).should().getArticleComment(commentId);
+    }
+
+    @DisplayName("[view][POST] 댓글 삭제 - 정상 호출")
+    @Test
+    void givenNothing_whenRequestingDeletion_thenRedirectsToArticleCommentManagement() throws Exception {
+        // Given
+        Long commentId = 1L;
+        willDoNothing().given(articleCommentManagementService).deleteArticleComment(commentId);
+
+        // When & Then
+        mvc.perform(
+                post("/management/article-comments/" + commentId)
+                        .with(csrf())
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/management/article-comments"))
+                .andExpect(redirectedUrl("management/article-comments"));
+
+        then(articleCommentManagementService).should().deleteArticleComment(commentId);
+    }
+
+    // --------------------- Fixture for Test ---------------------------
+    private ArticleCommentDto createArticleCommentDto(String content) {
+        return ArticleCommentDto.of(
+                1L,
+                1L,
+                createUserAccountDto(),
+                null,
+                content,
+                LocalDateTime.now(),
+                "Uno",
+                LocalDateTime.now(),
+                "Uno"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "unoTest",
+                "pw",
+                Set.of(RoleType.ADMIN),
+                "uno-test@email.com",
+                "uno-test",
+                "test memo"
+        );
+    }
 
 }

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -1,13 +1,11 @@
 package com.fastcampus.projectboardadmin.controller;
 
-import com.fastcampus.projectboardadmin.config.SecurityConfig;
-import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
 import com.fastcampus.projectboardadmin.service.ArticleCommentManagementService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -17,7 +15,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
 
 import static org.mockito.BDDMockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -26,7 +23,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View Controller - 댓글 관리")
-@Import(SecurityConfig.class)
+@Import(TestSecurityConfig.class)
 @WebMvcTest(ArticleCommentManagementController.class)
 class ArticleCommentManagementControllerTest {
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -110,8 +110,6 @@ class ArticleCommentManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
-                Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",
                 "test memo"

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -1,7 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
-import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import com.fastcampus.projectboardadmin.dto.ArticleDto;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
 import com.fastcampus.projectboardadmin.service.ArticleManagementService;
@@ -16,7 +15,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
 
 import static org.mockito.BDDMockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -128,8 +126,6 @@ class ArticleManagementControllerTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
           "unoTest",
-          "pw",
-          Set.of(RoleType.ADMIN),
           "uno-test@email.com",
           "uno-test",
           "test memo"

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -1,6 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
-import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import com.fastcampus.projectboardadmin.dto.ArticleDto;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
 import com.fastcampus.projectboardadmin.service.ArticleManagementService;
@@ -23,7 +23,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View Controller - 게시글 관리")
-@Import(SecurityConfig.class)
+@Import(TestSecurityConfig.class)
 @WebMvcTest(ArticleManagementController.class)
 class ArticleManagementControllerTest {
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -74,7 +74,7 @@ class ArticleManagementControllerTest {
         then(articleManagementService).should().getArticle(articleId);
     }
 
-    @DisplayName("[View][GET] 게시글 삭제 - 정상호출")
+    @DisplayName("[View][POST] 게시글 삭제 - 정상 호출")
     @Test
     void givenArticleId_whenRequestingDeletion_thenRedirectsToArticleManagement() throws Exception {
         // Given

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
@@ -1,6 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
-import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @DisplayName("View Root Controller")
-@Import(SecurityConfig.class)
+@Import(TestSecurityConfig.class)
 @WebMvcTest(MainController.class)
 class MainControllerTest {
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
@@ -1,6 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
-import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
 import com.fastcampus.projectboardadmin.service.UserAccountManagementService;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @DisplayName("View Controller - 회원 정보 관리")
-@Import(SecurityConfig.class)
+@Import(TestSecurityConfig.class)
 @WebMvcTest(UserAccountManagementController.class)
 class UserAccountManagementControllerTest {
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
@@ -1,14 +1,21 @@
 package com.fastcampus.projectboardadmin.controller;
 
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.service.UserAccountManagementService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -20,6 +27,8 @@ class UserAccountManagementControllerTest {
 
     private final MockMvc mvc;
 
+    @MockBean private UserAccountManagementService userAccountManagementService;
+
     public UserAccountManagementControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
     }
@@ -28,11 +37,58 @@ class UserAccountManagementControllerTest {
     @Test
     void givenNothing_whenRequestingUserAccountManagementView_thenReturnsUserAccountManagementView() throws Exception {
         // Given
+        given(userAccountManagementService.getUsers()).willReturn(List.of());
 
         // When & Then
         mvc.perform(get("/management/user-accounts"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("management/user-accounts"));    }
+                .andExpect(view().name("management/user-accounts"))
+                .andExpect(model().attribute("userAccounts", List.of()));
 
+        then(userAccountManagementService).should().getUsers();
+    }
+
+    @DisplayName("[View][GET] 1명의 회원 정보 - 정상 호출")
+    @Test
+    void givenUserId_whenRequestingUserAccount_thenReturnsUserAccount() throws Exception {
+        // Given
+        String userId = "uno";
+        UserAccountDto userAccountDto = createAccountDto(userId, "Uno");
+        given(userAccountManagementService.getUser(userId)).willReturn(userAccountDto);
+
+        // When & Then
+        mvc.perform(get("/mangement/user-accounts/" + userId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.userId").value(userId))  // 그런데 json 에 userId 는 없는데???
+                .andExpect(jsonPath("$.nickname").value(userAccountDto.nickname()));
+        then(userAccountManagementService).should().getUser(userId);
+    }
+
+    @DisplayName("[View][POST] 회원 정보 삭제 - 정상 호출")
+    @Test
+    void givenUserId_whenRequestingDeletion_thenRedirectsToUserAccountManagement() throws Exception {
+        // Given
+        String userId = "uno";
+        willDoNothing().given(userAccountManagementService).deleteUser(userId);
+
+        // When & Then
+        mvc.perform(post("/management/user-accounts/" + userId))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/management/user-accounts"))
+                .andExpect(redirectedUrl("management/user-accounts"));
+
+        then(userAccountManagementService).should().deleteUser(userId);
+    }
+
+    // ---------------- Fixture for Test ------------------------
+    private UserAccountDto createAccountDto(String userId, String nickname) {
+        return UserAccountDto.of(
+                userId,
+                "uno-test@email.com",
+                nickname,
+                "test memo"
+        );
+    }
 }

--- a/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/repository/JpaRepositoryTest.java
@@ -1,12 +1,11 @@
 package com.fastcampus.projectboardadmin.repository;
 
 
-import com.fastcampus.projectboardadmin.domain.UserAccount;
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.convert.DataSizeUnit;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -14,7 +13,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-import javax.swing.text.html.Option;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -33,33 +31,33 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest // slice test 로 모든 Spring Context 내 필요한 Bean Configuration 만 읽어옴. 때문에 test 용 Jpa configuration 을 별도로 생성하여 이를 사용해야 함.
 class JpaRepositoryTest {
 
-    private final UserAccountRepository userAccountRepository;
+    private final AdminAccountRepository adminAccountRepository;
 
 
-    public JpaRepositoryTest(@Autowired UserAccountRepository userAccountRepository) {
-        this.userAccountRepository = userAccountRepository;
+    public JpaRepositoryTest(@Autowired AdminAccountRepository adminAccountRepository) {
+        this.adminAccountRepository = adminAccountRepository;
     }
 
-    @DisplayName("회원정보 Select Test")
+    @DisplayName("관리자 정보 Select Test")
     @Test
-    void givenUserAccounts_whenSelecting_thenWorkFine() {
+    void givenAdminAccounts_whenSelecting_thenWorkFine() {
         // Given
 
 
         // When
-        Optional<UserAccount> userAccouts = userAccountRepository.findById("uno");
+        Optional<AdminAccount> userAccouts = adminAccountRepository.findById("uno");
 
         // Then
         assertThat(userAccouts)
                 .isNotNull();
     }
 
-    @DisplayName("회원 정보 Insert Test")
+    @DisplayName("관리자 정보 Insert Test")
     @Test
-    void givenUserAccount_whenInserting_thenWorkFine() {
+    void givenAdminAccount_whenInserting_thenWorkFine() {
         // Given
-        long previousCount = userAccountRepository.count();
-        UserAccount userAccount = UserAccount.of(
+        long previousCount = adminAccountRepository.count();
+        AdminAccount adminAccount = AdminAccount.of(
                 "test_id",
                 "pw",
                 Set.of(RoleType.DEVELOPER),
@@ -69,21 +67,21 @@ class JpaRepositoryTest {
         );
 
         // When
-        userAccountRepository.save(userAccount);
+        adminAccountRepository.save(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count())
+        assertThat(adminAccountRepository.count())
                 .isEqualTo(previousCount + 1);
     }
 
-    @DisplayName("회원 정보 Update Test")
+    @DisplayName("관리자 정보 Update Test")
     @Test
-    void givenUserAccountAndRoleType_whenInserting_thenWorksFine() {
+    void givenAdminAccountAndRoleType_whenInserting_thenWorksFine() {
         // Given
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
-        userAccount.addRoleType(RoleType.DEVELOPER);
-        userAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
-        userAccount.removeRoleType(RoleType.ADMIN);
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
+        adminAccount.addRoleType(RoleType.DEVELOPER);
+        adminAccount.addRoleTypes(List.of(RoleType.USER, RoleType.USER));
+        adminAccount.removeRoleType(RoleType.ADMIN);
 
         // When
         // 여기에서 save 요청은 기존에 존재하는 data 의 update 가 발생되어야 한다.
@@ -93,7 +91,7 @@ class JpaRepositoryTest {
         // UserAccount updatedAccount = userAccountRepository.save(userAccount);
         // 이렇게 강제적으로 바로 flush 를 하는 method 를 사용해야  update query 가 발생함을 확인할 수 있다. 
         // (test 끝난 후 내부적으로 별도의 rollback transaction 을 실행 시킴)
-        UserAccount updatedAccount = userAccountRepository.saveAndFlush(userAccount);
+        AdminAccount updatedAccount = adminAccountRepository.saveAndFlush(adminAccount);
 
         // Then
         assertThat(updatedAccount)
@@ -101,18 +99,18 @@ class JpaRepositoryTest {
                 .hasFieldOrPropertyWithValue("roleTypes", Set.of(RoleType.DEVELOPER, RoleType.USER));
     }
 
-    @DisplayName("회원정보 Delete Test")
+    @DisplayName("관리자 정보 Delete Test")
     @Test
-    void givenUserAccount_whenDeleting_thenWorkFine() {
+    void givenAdminAccount_whenDeleting_thenWorkFine() {
         // Given
-        long previousUserCount = userAccountRepository.count();
-        UserAccount userAccount = userAccountRepository.getReferenceById("uno");
+        long previousUserCount = adminAccountRepository.count();
+        AdminAccount adminAccount = adminAccountRepository.getReferenceById("uno");
 
         // When
-        userAccountRepository.delete(userAccount);
+        adminAccountRepository.delete(adminAccount);
 
         // Then
-        assertThat(userAccountRepository.count())
+        assertThat(adminAccountRepository.count())
                 .isEqualTo(previousUserCount - 1);
     }
 

--- a/src/test/java/com/fastcampus/projectboardadmin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/AdminAccountServiceTest.java
@@ -1,0 +1,134 @@
+package com.fastcampus.projectboardadmin.service;
+
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
+import com.fastcampus.projectboardadmin.repository.AdminAccountRepository;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL_LONG;
+import static org.mockito.BDDMockito.*;
+
+
+@DisplayName("Business Logic - 관리자 회원")
+@ExtendWith(MockitoExtension.class) // Slice test X Mock test 만 사용
+class AdminAccountServiceTest {
+
+    @InjectMocks private AdminAccountService sut;
+    @Mock private AdminAccountRepository adminAccountRepository;
+
+    @DisplayName("존재하는 관리자 ID 를 검색하면, Optional 로 관리자 정보를 반환")
+    @Test
+    void givenExistentAdminId_whenSearching_thenReturnsOptionalAdminAccountData() {
+        // Given
+        String username = "uno";
+        given(adminAccountRepository.findById(username)).willReturn(Optional.of(createAdminAccount(username, Set.of(RoleType.USER))));
+
+        // When
+        Optional<AdminAccountDto> result = sut.searchUser(username);
+
+        // Then
+        assertThat(result).isPresent();
+        then(adminAccountRepository).should().findById(username);
+    }
+
+    @DisplayName("존재하지 않는 관리자 ID 를 검색하면, 빈 Optional 을 반환")
+    @Test
+    void givenNonexistentAminId_whenSearching_thenReturnsEmptyOptional() {
+        // Given
+        String username = "no_uno";
+        given(adminAccountRepository.findById(username)).willReturn(Optional.empty());
+
+        // When
+        Optional<AdminAccountDto> result = sut.searchUser(username);
+
+        // Then
+        assertThat(result).isEmpty();
+        then(adminAccountRepository).should().findById(username);
+    }
+
+    @DisplayName("관리자 정보를 입력하면, 새로운 관리자를 저장하여 가입시키고 해당 관리자 정보를 반환")
+    @Test
+    void givenAdminParams_whenSaving_thenSavesAdminAccount() {
+        // Given
+        AdminAccount admin = createAdminAccount("uno", Set.of(RoleType.USER));
+        given(adminAccountRepository.save(admin)).willReturn(admin);
+
+        // When
+        AdminAccountDto result = sut.saveUser(
+                admin.getUserId(),
+                admin.getUserPassword(),
+                admin.getRoleTypes(),
+                admin.getEmail(),
+                admin.getNickname(),
+                admin.getMemo()
+        );
+
+        // Then
+        assertThat(result)
+                .hasFieldOrPropertyWithValue("userId", admin.getUserId())
+                .hasFieldOrPropertyWithValue("userPassword", admin.getUserPassword())
+                .hasFieldOrPropertyWithValue("roleType", admin.getRoleTypes())
+                .hasFieldOrPropertyWithValue("email", admin.getEmail())
+                .hasFieldOrPropertyWithValue("nickname", admin.getNickname())
+                .hasFieldOrPropertyWithValue("memo", admin.getMemo())
+                .hasFieldOrPropertyWithValue("createdBy", admin.getCreatedAt())
+                .hasFieldOrPropertyWithValue("modifiedBy", admin.getModifiedBy());
+
+        then(adminAccountRepository).should().save(admin);
+    }
+
+
+    @DisplayName("전체 관리자 회원 조회")
+    @Test
+    void givenNothing_whenRequestingAdminAccounts_thenReturnsAdminAccounts () {
+        // Given
+        given(adminAccountRepository.findAll()).willReturn(List.of());
+
+        // When
+        List<AdminAccountDto> result = sut.users();
+
+        // Then
+        assertThat(result).hasSize(0);
+        then(adminAccountRepository).should().findAll();
+    }
+
+    @DisplayName("관리자 ID 를 입력하면, 관리자을 삭제한다.")
+    @Test
+    void givenAdminAccountId_whenDeleting_thenDeletesAdminAccount() {
+        // Given
+        String userId = "uno";
+        willDoNothing().given(adminAccountRepository).deleteById(userId);
+
+        // When
+        sut.deleteUser(userId);
+
+        // Then
+        then(adminAccountRepository).should().deleteById(userId);
+    }
+
+    // -------------------- Fixture for Test ---------------------
+
+    private AdminAccount createAdminAccount(String username, Set<RoleType> roleType) {
+        return AdminAccount.of(
+                username,
+                "password",
+                Set.of(RoleType.ADMIN),
+                "a@email.com",
+                "Uno",
+                "memo"
+        );
+    }
+
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -1,0 +1,184 @@
+package com.fastcampus.projectboardadmin.service;
+
+import com.fastcampus.projectboardadmin.domain.constant.RoleType;
+import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.properties.ProjectProperty;
+import com.fastcampus.projectboardadmin.dto.response.CommentClientResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+
+@ActiveProfiles("test")
+@DisplayName("Business Logic - 댓글 관리")
+class ArticleCommentManagementServiceTest {
+
+    // 1. 실제 API server 통신 상태 test
+    @Disabled("실재 API 호출 결과 관찰이 필요할 경우 활성화")
+    @DisplayName("실제 API 호출 TEST")
+    @SpringBootTest
+    @Nested
+    class RealApiTest {
+        private final ArticleCommentManagementService sut;
+
+        public RealApiTest(ArticleCommentManagementService sut) {
+            this.sut = sut;
+        }
+
+        @DisplayName("댓글 API 를 호출하면, 댓글을 가져온다")
+        @Test
+        void givenNothing_whenCallingCommentsApi_thenReturnsComments() {
+            // Given
+
+            // When
+            List<ArticleCommentDto> result = sut.getArticleComments();
+
+            // Then
+            System.out.println(result.stream().findFirst());
+            assertThat(result).isNotNull();
+        }
+    }
+
+    // 2. Mocking server 를 사용하는 test
+    @DisplayName("API mocking test")
+    @EnableConfigurationProperties(ProjectProperty.class)
+    @AutoConfigureWebClient(registerRestTemplate = true)
+    @RestClientTest(ArticleCommentManagementService.class)
+    @Nested
+    class RestTemplateTest {
+
+        private final ArticleCommentManagementService sut;
+        private final ProjectProperty projectProperty;
+        private final MockRestServiceServer server;
+        private final ObjectMapper mapper;
+
+        @Autowired
+        public RestTemplateTest(
+                ArticleCommentManagementService sut,
+                ProjectProperty projectProperty,
+                MockRestServiceServer server,
+                ObjectMapper mapper) {
+            this.sut = sut;
+            this.projectProperty = projectProperty;
+            this.server = server;
+            this.mapper = mapper;
+        }
+
+        @DisplayName("댓글 목록 API를 호출하면, 댓글들을 가져온다")
+        @Test
+        void givenNothing_whenCallingArticleCommentsApi_thenReturnsArticleComments() throws Exception {
+            // given
+            ArticleCommentDto expectedComment = createArticleCommentDto("댓글");
+            CommentClientResponse expectedResponse = CommentClientResponse.of(List.of(expectedComment));
+
+            server
+                    .expect(requestTo(projectProperty.board().url() + "/api/articels?size=10000"))
+                    .andRespond(withSuccess(
+                            mapper.writeValueAsString(expectedResponse),
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            // when
+            List<ArticleCommentDto> result = sut.getArticleComments();
+
+            // then
+            assertThat(result).first()
+                    .hasFieldOrPropertyWithValue("id", expectedComment.id())
+                    .hasFieldOrPropertyWithValue("content", expectedComment.content())
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedComment.userAccountDto().nickname());
+
+            server.verify();
+        }
+
+        @DisplayName("댓글 API를 호출하면, 댓글을 가져온다")
+        @Test
+        void givenNothing_whenCallingArticleCommentApi_thenReturnsArticleComment() throws Exception {
+            // given
+            Long commentId = 1L;
+            ArticleCommentDto expectedComment = createArticleCommentDto("댓글");
+
+            server
+                    .expect(requestTo(projectProperty.board().url() + "/api/articleComments/" + commentId))
+                    .andRespond(withSuccess(
+                            mapper.writeValueAsString(expectedComment),
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            // when
+            ArticleCommentDto result = sut.getArticleComment(commentId);
+
+            // then
+            assertThat(result)
+                    .hasFieldOrPropertyWithValue("id", expectedComment.id())
+                    .hasFieldOrPropertyWithValue("content", expectedComment.content())
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedComment.userAccountDto().nickname());
+            server.verify();
+        }
+
+        @DisplayName("댓글 ID 로 댓글 삭제 API를 호출하면, 댓글을 삭제한다.")
+        @Test
+        void givenNothing_whenCallingDeleteArticleCommentApi_thenReturnsDeleteArticleComment() throws Exception {
+            // given
+            long commentId = 1L;
+
+            server
+                    .expect(requestTo(projectProperty.board().url() + "/api/acticleComments/" + commentId))
+                    .andExpect(method(HttpMethod.DELETE))
+                    .andRespond(withSuccess());
+
+            // when
+            sut.deleteArticleComment(commentId);
+
+            // then
+            server.verify();
+        }
+    }
+
+    // ------------- Fixture for Test ----------------
+
+    private ArticleCommentDto createArticleCommentDto(String content) {
+        return ArticleCommentDto.of(
+                1L,
+                1L,
+                createUserAccountDto(),
+                null,
+                content,
+                LocalDateTime.now(),
+                "Uno",
+                LocalDateTime.now(),
+                "Uno"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "unoTest",
+                "pw",
+                Set.of(RoleType.ADMIN),
+                "uno-test@email.com",
+                "uno-test",
+                "test memo"
+        );
+    }
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -85,6 +85,8 @@ class ArticleCommentManagementServiceTest {
             this.mapper = mapper;
         }
 
+        // TODO: 게시글과 달리 화면 요청 api 로 확인했을 때 회원 정보를 한방에 모아서 보내주는 건 없었는데...
+        //       CRUD 요청에서 findAll 로 하면 다 가져올수 있는건지... 모르겠다..
         @DisplayName("댓글 목록 API를 호출하면, 댓글들을 가져온다")
         @Test
         void givenNothing_whenCallingArticleCommentsApi_thenReturnsArticleComments() throws Exception {
@@ -174,8 +176,6 @@ class ArticleCommentManagementServiceTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
                 "unoTest",
-                "pw",
-                Set.of(RoleType.ADMIN),
                 "uno-test@email.com",
                 "uno-test",
                 "test memo"

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -196,8 +196,6 @@ class ArticleManagementServiceTest {
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
           "unoTest",
-          "pw",
-          Set.of(RoleType.ADMIN),
           "uno-test@email.com",
           "uno-test",
           "test memo"

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -53,9 +53,9 @@ class ArticleManagementServiceTest {
             this.sut = sut;
         }
 
-        @DisplayName("게시글 API 를 호출하면, 게시글을 가져온다.")
+        @DisplayName("게시글 API 를 호출하면, 게시글들을 가져온다.")
         @Test
-        void given_when_then() {
+        void givenNothing_whenCallingArticlesApi_thenReturnsArticles() {
             // Given
 
             // When
@@ -68,8 +68,8 @@ class ArticleManagementServiceTest {
         }
     }
 
-    // 2. Mocking data를 사용하는 test
-    @DisplayName("API mocking TESET")
+    // 2. Mocking server 를 사용하는 test
+    @DisplayName("API mocking TEST")
     @EnableConfigurationProperties(ProjectProperty.class)  // slice test 할때 configurationProperty 는 기본 비활성화 이므로 이를 활성화 시킴.
     @AutoConfigureWebClient(registerRestTemplate = true) // 사용자가 직접 가져올 bean 을 설정?
     @RestClientTest(ArticleManagementService.class)

--- a/src/test/java/com/fastcampus/projectboardadmin/service/UserAccountManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/UserAccountManagementServiceTest.java
@@ -1,0 +1,168 @@
+package com.fastcampus.projectboardadmin.service;
+
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fastcampus.projectboardadmin.dto.properties.ProjectProperty;
+import com.fastcampus.projectboardadmin.dto.response.UserAccountClientResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+
+@DisplayName("Business Logic - 일반 회원 관리")
+@ActiveProfiles("test")
+class UserAccountManagementServiceTest {
+
+    // 1. 실제 API server 통신 상태 test
+    @Disabled("실제 API 호출 결과 확인을 위한 test 이므로 logic test 상황에서는 비활성화")
+    @DisplayName("실제 API 호출 Test")
+    @SpringBootTest
+    @Nested
+    class RealApiTest {
+
+        private final UserAccountManagementService sut;
+
+        public RealApiTest(UserAccountManagementService sut) {
+            this.sut = sut;
+        }
+
+        @DisplayName("일반 회원 정보 API 를 호출하면, 회원 정보를 가저온다.")
+        @Test
+        void givenNothing_whenCallUserAccountsApi_thenReturnsUserAccounts() {
+            // Given
+
+            // When
+            List<UserAccountDto> result = sut.getUsers();
+
+            // Then
+            System.out.println(result.stream().findFirst());
+            assertThat(result).isNotNull();
+        }
+    }
+
+    // 2. Mocking server 를 사용하는 test
+    @DisplayName("API Mocking test")
+    @EnableConfigurationProperties(ProjectProperty.class)
+    @AutoConfigureWebClient(registerRestTemplate = true)
+    @RestClientTest(UserAccountManagementService.class)
+    @Nested
+    class RestTemplateTest {
+
+        private  final UserAccountManagementService sut;
+        private final ProjectProperty projectProperty;
+        private final MockRestServiceServer server;
+        private final ObjectMapper mapper;
+
+        @Autowired
+        public RestTemplateTest(
+                UserAccountManagementService sut,
+                ProjectProperty projectProperty,
+                MockRestServiceServer server,
+                ObjectMapper mapper
+        ) {
+            this.sut = sut;
+            this.projectProperty = projectProperty;
+            this.server = server;
+            this.mapper = mapper;
+        }
+
+        // TODO: 게시글과 달리 화면 요청 api 로 확인했을 때 회원 정보를 한방에 모아서 보내주는 건 없었는데...
+        //       CRUD 요청에서 findAll 로 하면 다 가져올수 있는건지... 모르겠다..
+        @DisplayName("일반 회원 정보 목록 API 를 호출하면, 전체 일반 회원 정보를 가져온다.")
+        @Test
+        void givenNothing_whenCallingUserAccountsApi_thenReturnsUserAccounts() throws Exception {
+            // Given
+            UserAccountDto expectedUser = createUserAccountDto("uno", "Uno");
+            UserAccountClientResponse expectedResponse = UserAccountClientResponse.of(List.of(expectedUser));
+
+            server
+                    .expect(requestTo(projectProperty.board().url() + "/management/user-accounts"))
+                    .andRespond(withSuccess(
+                            mapper.writeValueAsString(expectedResponse),
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            // When
+            List<UserAccountDto> result = sut.getUsers();
+
+            // Then
+            assertThat(result).first()
+                    .hasFieldOrPropertyWithValue("userId", expectedUser.userId())
+                    .hasFieldOrPropertyWithValue("nickname", expectedUser.nickname());
+
+            server.verify();
+        }
+
+        @DisplayName("회원 ID와 함께 회원 API를 호출하면, 회원을 가져온다.")
+        @Test
+        void givenUserAccountId_whenCallingUserAccountApi_thenReturnsUserAccount() throws Exception {
+            // Given
+            String userId = "uno";
+            UserAccountDto expectedUser = createUserAccountDto(userId, "Uno");
+
+            server
+                    .expect(requestTo(projectProperty.board().url() + "/management/user-accounts/" + userId))
+                    .andRespond(withSuccess(
+                            mapper.writeValueAsString(expectedUser),
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            // When
+            UserAccountDto result = sut.getUser(userId);
+
+            // Then
+            assertThat(result)
+                    .hasFieldOrPropertyWithValue("userId", expectedUser.userId())
+                    .hasFieldOrPropertyWithValue("nickname", expectedUser.nickname());
+
+            server.verify();
+        }
+
+        @DisplayName("회원 ID와 함께 삭제 API를 호출하면, 회원 정보를 삭제한다.")
+        @Test
+        void givenUserAccountId_whenCallingDeleteUserAccountApi_thenReturnsUserAccount() throws Exception {
+            // Given
+            String userId = "uno";
+            server
+                    .expect(requestTo(projectProperty.board().url() + "/management/user-accounts/" + userId))
+                    .andExpect(method(HttpMethod.DELETE))
+                    .andRespond(withSuccess());
+
+            // When
+            sut.deleteUser(userId);
+
+            // Then
+            server.verify();
+        }
+    }
+
+    // -------------- Fixture for Test ----------------
+    private UserAccountDto createUserAccountDto(String userId, String nickname) {
+        return UserAccountDto.of(
+                userId,
+                "uno-test@email.com",
+                nickname,
+                "test memo"
+        );
+    }
+
+}


### PR DESCRIPTION
4xx / 5xx 에러 화면 출력에 대해서, AdminLTE  template 을 적용하여, view 를 구성

Spring error page 구성은 template - error  folder 해당 error code 파일명으로 작성하면 된다.

## Reference
* spring docs (https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#web.servlet.spring-mvc.error-handling)

To map all 5xx errors by using a FreeMarker template, your directory structure would be as follows:

src/
 +- main/
     +- java/
     |   + <source code>
     +- resources/
         +- templates/
             +- error/
             |   +- 5xx.ftlh (thymeleaf -> html)
             +- <other templates>
