### PR TITLE
기본 에러 페이지 구현

### DIFF
--- a/src/main/resources/templates/error/4xx.html
+++ b/src/main/resources/templates/error/4xx.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head id="layout-head">
+  <meta charset="UTF-8">
+  <title>4XX 에러</title>
+</head>
+<body class="hold-transition sidebar-mini">
+<div class="wrapper">
+  <header id="layout-header">헤더 삽입부</header>
+  <aside id="layout-left-aside">왼쪽 사이드 바 삽입부</aside>
+
+  <main class="content-wrapper">
+    <!-- Content Header (Page header) -->
+    <section class="content-header">
+      <div class="container-fluid">
+        <div class="row mb-2">
+          <div class="col-sm-6">
+            <h1 id="main-header-title" class="m-0">Error Page</h1>
+          </div>
+          <div class="col-sm-6">
+            <ol class="breadcrumb float-sm-right">
+              <li class="breadcrumb-item"><a id="breadcrumb-home">Home</a></li>
+              <li id="breadcrumb-current-page" class="breadcrumb-item active지">Error Page</li>
+            </ol>
+          </div>
+        </div>
+      </div><!-- /.container-fluid -->
+    </section>
+
+    <!-- Main content -->
+    <section class="content">
+      <div class="error-page">
+        <h2 id="error-status" class="headline text-warning">4XX</h2>
+
+        <div class="error-content">
+          <h3><i class="fas fa-exclamation-triangle text-warning"></i> Oops!</h3>
+
+          <p>
+            <span id="error-message">Something went wrong.</span>
+          </p>
+        </div>
+        <!-- /.error-content -->
+      </div>
+      <!-- /.error-page -->
+    </section>
+    <!-- /.content -->
+  </main>
+  <!-- /.content-wrapper -->
+
+  <aside id="layout-right-aside">오른쪽 사이드 바 삽입부</aside>
+  <footer id="layout-footer">푸터 삽입부</footer>
+</div>
+<!-- ./wrapper -->
+
+<!--/* REQUIRED SCRIPTS */-->
+<script id="layout-scripts">/* 공통 스크립트 삽입부 */</script>
+
+<!--/* 페이지 전용 스크립트 */-->
+</body>
+</html>

--- a/src/main/resources/templates/error/4xx.th.xml
+++ b/src/main/resources/templates/error/4xx.th.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
+    <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
+    <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
+    <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
+    <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
+    <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+
+    <attr sel="#main-header-title" th:text="'에러 페이지'" />
+    <attr sel="#breadcrumb-home" th:href="@{/}" th:text="'홈'" />
+    <attr sel="#breadcrumb-current-page" th:text="'에러 페이지'" />
+    <attr sel="#error-status" th:text="${#response.status}" />
+    <attr sel="#error-message" th:text="'잘못된 호출입니다.'" />
+</thlogic>

--- a/src/main/resources/templates/error/5xx.html
+++ b/src/main/resources/templates/error/5xx.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head id="layout-head">
+    <meta charset="UTF-8">
+    <title>5XX 에러</title>
+</head>
+<body class="hold-transition sidebar-mini">
+<div class="wrapper">
+    <header id="layout-header">헤더 삽입부</header>
+    <aside id="layout-left-aside">왼쪽 사이드 바 삽입부</aside>
+
+    <main class="content-wrapper">
+        <!-- Content Header (Page header) -->
+        <section class="content-header">
+            <div class="container-fluid">
+                <div class="row mb-2">
+                    <div class="col-sm-6">
+                        <h1 id="main-header-title" class="m-0">Error Page</h1>
+                    </div>
+                    <div class="col-sm-6">
+                        <ol class="breadcrumb float-sm-right">
+                            <li class="breadcrumb-item"><a id="breadcrumb-home">Home</a></li>
+                            <li id="breadcrumb-current-page" class="breadcrumb-item active지">Error Page</li>
+                        </ol>
+                    </div>
+                </div>
+            </div><!-- /.container-fluid -->
+        </section>
+
+        <!-- Main content -->
+        <section class="content">
+            <div class="error-page">
+                <h2 id="error-status" class="headline text-danger">5XX</h2>
+
+                <div class="error-content">
+                    <h3><i class="fas fa-exclamation-triangle text-danger"></i> Oops!</h3>
+
+                    <p>
+                        <span id="error-message">Something went wrong.</span>
+                    </p>
+                </div>
+                <!-- /.error-content -->
+            </div>
+            <!-- /.error-page -->
+        </section>
+        <!-- /.content -->
+    </main>
+    <!-- /.content-wrapper -->
+
+    <aside id="layout-right-aside">오른쪽 사이드 바 삽입부</aside>
+    <footer id="layout-footer">푸터 삽입부</footer>
+</div>
+<!-- ./wrapper -->
+
+<!--/* REQUIRED SCRIPTS */-->
+<script id="layout-scripts">/* 공통 스크립트 삽입부 */</script>
+
+<!--/* 페이지 전용 스크립트 */-->
+</body>
+</html>

--- a/src/main/resources/templates/error/5xx.th.xml
+++ b/src/main/resources/templates/error/5xx.th.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
+    <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
+    <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
+    <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
+    <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
+    <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+
+    <attr sel="#main-header-title" th:text="'에러 페이지'" />
+    <attr sel="#breadcrumb-home" th:href="@{/}" th:text="'홈'" />
+    <attr sel="#breadcrumb-current-page" th:text="'에러 페이지'" />
+    <attr sel="#error-status" th:text="${#response.status}" />
+    <attr sel="#error-message" th:text="'알 수 없는 에러가 발생했어요!'" />
+</thlogic>


### PR DESCRIPTION
4xx / 5xx 에러 화면 출력에 대해서, AdminLTE  template 을 적용하여, view 를 구성

Spring error page 구성은 template - error  folder 해당 error code 파일명으로 작성하면 된다.

## Reference
* spring docs (https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#web.servlet.spring-mvc.error-handling)

To map all 5xx errors by using a FreeMarker template, your directory structure would be as follows:

src/
 +- main/
     +- java/
     |   + <source code>
     +- resources/
         +- templates/
             +- error/
             |   +- 5xx.ftlh (thymeleaf -> html)
             +- <other templates>

This closes #47  