### PR TITLE
[관리자] 게시글 관리 page 구현

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/ArticleManagementController.java
@@ -1,20 +1,48 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.dto.response.ArticleResponse;
+import com.fastcampus.projectboardadmin.service.ArticleManagementService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 
+@RequiredArgsConstructor
 @RequestMapping("/management/articles")
 @Controller
 public class ArticleManagementController {
 
+    private final ArticleManagementService articleManagementService;
+
+    // 게시글 list view
     @GetMapping
     public String article(Model model) {
+        model.addAttribute(
+                "articles",
+                articleManagementService
+                        .getArticles()
+                        .stream()
+                        .map(ArticleResponse::withoutContent)
+                        .toList()
+        );
+
         return "management/articles";
+    }
+
+    // Modal request 용
+    @ResponseBody
+    @GetMapping("/{id}")
+    public ArticleResponse article(@PathVariable Long id) {
+        return ArticleResponse.withContent(articleManagementService.getArticle(id));
+    }
+
+    @PostMapping("/{id}")
+    public String deleteArticle(@PathVariable Long id) {
+        articleManagementService.deleteArticle(id);
+        return "redirect:/management/articles";
     }
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/response/ArticleResponse.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/response/ArticleResponse.java
@@ -1,0 +1,57 @@
+package com.fastcampus.projectboardadmin.dto.response;
+
+import com.fastcampus.projectboardadmin.dto.ArticleDto;
+import com.fastcampus.projectboardadmin.dto.UserAccountDto;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDateTime;
+
+// ArticleManagementSerive 에서 REST API 요청로 받은 data 를
+// ArticleDto (단건 게시글 )또는 ArticleClientResponse (게시글 리스트) 에 담아서
+// controller 로 보내면, controller 에서 여기 ArticleResponse 에 담아서 model 에 보낸다.
+
+// @JsonUnclude : jackson annotation
+// Nullable 한 field 를 어떻게 다룰것인가를 정할 수 있다.
+// JsonInclude.Include.NON_NULL : Non null field 만 jackson annotation 에 포함시키겠다.
+// 해당 조건이 없는 기본 상태에서 만약 명시된 field 값이 없다면 해당 field value 를 null 로 체운다.
+// 그런다 해당 조건으로 진행하면 아에 해당 field 를 빼버린다.
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ArticleResponse(
+        Long id,
+        UserAccountDto userAccount,
+        String title,
+        String content,
+        LocalDateTime createdAt
+) {
+
+    public static ArticleResponse of(
+            Long id,
+            UserAccountDto userAccount,
+            String title,
+            String content,
+            LocalDateTime createdAt
+    ) {
+        return new ArticleResponse(id, userAccount, title, content, createdAt);
+    }
+
+    public static ArticleResponse withContent(ArticleDto dto) {
+        return new ArticleResponse(
+                dto.id(),
+                dto.userAccount(),
+                dto.title(),
+                dto.content(),
+                dto.createdAt()
+        );
+    }
+
+    public static ArticleResponse withoutContent(ArticleDto dto) {
+        return new ArticleResponse(
+                dto.id(),
+                dto.userAccount(),
+                dto.title(),
+                null,
+                dto.createdAt()
+        );
+    }
+
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/service/ArticleManagementService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/ArticleManagementService.java
@@ -1,24 +1,59 @@
 package com.fastcampus.projectboardadmin.service;
 
 import com.fastcampus.projectboardadmin.dto.ArticleDto;
+import com.fastcampus.projectboardadmin.dto.properties.ProjectProperty;
+import com.fastcampus.projectboardadmin.dto.response.ArticleClientResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
 public class ArticleManagementService {
 
+    private final RestTemplate restTemplate;
+    private final ProjectProperty projectProperty;
+
     public List<ArticleDto> getArticles() {
-        return List.of();
+        URI uri = UriComponentsBuilder
+                .fromHttpUrl(projectProperty.board().url() + "/api/articles")
+                .queryParam("size", 10000)
+                .build()
+                .toUri();
+
+        ArticleClientResponse response = restTemplate.getForObject(uri, ArticleClientResponse.class);
+
+        return Optional.ofNullable(response)
+                .orElseGet(ArticleClientResponse::empty)
+                .articles();
     }
 
-    public ArticleDto getArticle(Long ArticleId) {
-        return null;
+    public ArticleDto getArticle(Long articleId) {
+        URI uri = UriComponentsBuilder
+                .fromHttpUrl(projectProperty.board().url() + "/api/articles/" + articleId)
+                .build()
+                .toUri();
+
+        ArticleDto response = restTemplate.getForObject(uri, ArticleDto.class);
+
+        return Optional.ofNullable(response)
+                .orElseThrow(
+                        () -> new NoSuchElementException("게시글이 없습니다. - articleId: " + articleId)
+                );
     }
 
-    public void deleteArticle(Long ArticleId) {
+    public void deleteArticle(Long articleId) {
+        URI uri = UriComponentsBuilder
+                .fromHttpUrl(projectProperty.board().url() + "/api/articles/" + articleId)
+                .build()
+                .toUri();
 
+        restTemplate.delete(uri);
     }
 }

--- a/src/main/resources/templates/management/articles.th.xml
+++ b/src/main/resources/templates/management/articles.th.xml
@@ -8,4 +8,22 @@
     <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
     <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
     <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+
+    <attr sel="#main-table">
+        <attr sel="thead/tr">
+            <attr sel="th[0]" th:text="'ID'" />
+            <attr sel="th[1]" th:text="'제목'" />
+            <attr sel="th[2]" th:text="'작성자'" />
+            <attr sel="th[3]" th:text="'작성일시'" />
+        </attr>
+
+        <attr sel="tbody" th:remove="all-but-first">
+            <attr sel="tr[0]" th:each="article : ${articles}">
+                <attr sel="td[0]" th:text="${article.id}" />
+                <attr sel="td[1]/a" th:text="${article.title}" th:href="@{#}" th:data-id="${article.id}" />
+                <attr sel="td[2]" th:text="${article.userAccount.nickname}" />
+                <attr sel="td[3]/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
+            </attr>
+        </attr>
+    </attr>
 </thlogic>

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -36,6 +37,7 @@ class ArticleManagementControllerTest {
         this.mvc = mvc;
     }
 
+    @WithMockUser(username = "tester", roles = "USER")
     @DisplayName("[view][GET] 게시글 관리 페이지 - 정상 호출")
     @Test
     void givenNothing_whenRequestingArticleManagementView_thenReturnsArticleManagementView() throws Exception {
@@ -52,6 +54,7 @@ class ArticleManagementControllerTest {
         then(articleManagementService).should().getArticles();
     }
 
+    @WithMockUser(username = "tester", roles = "USER")
     @DisplayName("[data][GET] 게시글 1개 - 정상 호출")
     @Test
     void givenAritcleId_whenRequestingArticle_thenReturnsArticle() throws Exception {
@@ -72,6 +75,7 @@ class ArticleManagementControllerTest {
         then(articleManagementService).should().getArticle(articleId);
     }
 
+    @WithMockUser(username = "tester", roles = "MANAGER")
     @DisplayName("[View][POST] 게시글 삭제 - 정상 호출")
     @Test
     void givenArticleId_whenRequestingDeletion_thenRedirectsToArticleManagement() throws Exception {
@@ -86,7 +90,7 @@ class ArticleManagementControllerTest {
                 )
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:/management/articles"))
-                .andExpect(redirectedUrl("management/articles"));
+                .andExpect(redirectedUrl("/management/articles"));
 
         then(articleManagementService).should().deleteArticle(articleId);
     }

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -49,6 +49,7 @@ class ArticleManagementServiceTest {
     class RealApiTest {
         private final ArticleManagementService sut;
 
+        @Autowired
         public RealApiTest(ArticleManagementService sut) {
             this.sut = sut;
         }
@@ -162,7 +163,7 @@ class ArticleManagementServiceTest {
             Long articleId = 1L;
 
             server
-                    .expect(requestTo(projectProperties.board().url() + "/api/articels/" + articleId))
+                    .expect(requestTo(projectProperties.board().url() + "/api/articles/" + articleId))
                     .andExpect(method(HttpMethod.DELETE))
                     .andRespond(withSuccess());
 


### PR DESCRIPTION
게시글 관리 페이지 실제 동작을 위한  Controller, Service, View  logic 구현 몇 test 검사 완료.

articles.th.xml
 - 기존 정적인 view 대신 실제 게시글을 data 를 REST API 로 받아서 table 를 생성 하는 thymeleaf logic 구현

 ArticleResponse
 - Controller 에서 spring MVC 로 보내는 data 에 대한 DTO
 - Service -> Controller  단계 DTO 로부터 data 를 mapping 받을 때, 값이 없는 field 에 대해서는 해당 field 값을 받지 않고 자체적으로 null 를 생성하여  채울 수 있도록 @JsonInclude annotation 사용 (?)

ArticleManagementService
  1. 게시글 전체 리스트 REST API 요청을 넣고, 응답 data 를 받아 회신한다.
  2. 게시글 하나 REST API 요청을 넣고, 응답 data 를 받아 회신한다.
  3. 게시글 id 에 대해, REST API 로 data 삭제 요청한다.

ArticleManagementController
  1. 게시글 관리 페이지 view 요청에 대해서 게시글 전체 리스트를 service 에 요청하고, 이를 받아서 model 에 mapping 시킨다.  이때, 전송 data 의 크기를 줄이기 위해 본문없이 가져온다.
  2. 단건 게시글 요청 (modal page pop-up) 에 대해 , 해당 게시글 (본문포함)을 service에 요청하고, 이를 받아서 반환한다.
  3. Data REST API 에 게시글 한건의 삭제를 요청한다.

ArticleManagementControllerTest
- MockUser 를 적용하여, Test 작업 시 인증 문제를 해결
- 오타수정

This closes #25