### PR TITLE
[관리자] 로그인 페이지 구현

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .mvcMatchers(HttpMethod.POST, "/**").hasAnyRole(rolesAboveManager) // mvcMatchers() 는 spring 3.0 에서 requestMatchers 로 변경 됨.
                         .mvcMatchers(HttpMethod.DELETE, "/**").hasAnyRole(rolesAboveManager)
-                        .anyRequest().permitAll() // permitAll() 에서 인증 필요로 변경
+                        .anyRequest().authenticated() // permitAll() 에서 인증 필요로 변경
                 )
                 .formLogin(withDefaults()) // 기본값을 내부적으로 설정. 따라서 method chaining 을 위한 and() 가 필요 없어짐.
                 .logout(logout -> logout.logoutSuccessUrl("/"))

--- a/src/main/java/com/fastcampus/projectboardadmin/controller/AdminAccountController.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/AdminAccountController.java
@@ -3,12 +3,8 @@ package com.fastcampus.projectboardadmin.controller;
 import com.fastcampus.projectboardadmin.dto.response.AdminAccountResponse;
 import com.fastcampus.projectboardadmin.service.AdminAccountService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,8 +15,8 @@ public class AdminAccountController {
 
     private final AdminAccountService adminAccountService;
 
-    @RequestMapping("/admin/members")
-    public String adminAccount (Model model) {
+    @GetMapping("/admin/members")
+    public String members () { // JsGrid table 에 정보들은 model attribute 로 넘겨주지 않아도 된다??
         return "admin/members";
     }
 
@@ -52,16 +48,15 @@ public class AdminAccountController {
     @ResponseBody
     @GetMapping("/api/admin/members")
     public List<AdminAccountResponse> getMembers() {
-        return List.of();
-//        return adminAccountService.users().stream()
-//                .map(AdminAccountResponse::from)
-//                .toList();
+        return adminAccountService.users().stream()
+                .map(AdminAccountResponse::from)
+                .toList();
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT) // 응답 HttpStatus 를 특정 code 로 지정하기 위해 사용? (NO_CONTENT - 204 (delete 에 주로 사용), OK - 200 (default) CREATED - 200 (insert))
     @ResponseBody
     @DeleteMapping("/api/admin/members/{userId}")
     public void delete(@PathVariable String userId) {
-//        adminAccountService.deleteUser(userId);
+        adminAccountService.deleteUser(userId);
     }
 }

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/AdminAccountDto.java
@@ -9,7 +9,7 @@ import java.util.Set;
 public record AdminAccountDto(
         String userId,
         String userPassword,
-        Set<RoleType> roleTeyps,
+        Set<RoleType> roleTypes,
         String email,
         String nickname,
         String memo,
@@ -84,7 +84,7 @@ public record AdminAccountDto(
         return AdminAccount.of(
                 userId,
                 userPassword,
-                roleTeyps,
+                roleTypes,
                 email,
                 nickname,
                 memo

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/response/AdminAccountResponse.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/response/AdminAccountResponse.java
@@ -38,7 +38,7 @@ public record AdminAccountResponse(
     public static AdminAccountResponse from(AdminAccountDto dto) {
         return AdminAccountResponse.of(
                 dto.userId(),
-                dto.roleTeyps().stream()
+                dto.roleTypes().stream()
                         .map(RoleType::getDescription)
                         .collect(Collectors.joining(", ")),
                 dto.email(),

--- a/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/dto/security/BoardAdminPrincipal.java
@@ -71,7 +71,7 @@ public record BoardAdminPrincipal(
         return BoardAdminPrincipal.of(
                 dto.userId(),
                 dto.userPassword(),
-                dto.roleTeyps(),
+                dto.roleTypes(),
                 dto.email(),
                 dto.nickname(),
                 dto.memo()

--- a/src/main/java/com/fastcampus/projectboardadmin/service/AdminAccountService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/AdminAccountService.java
@@ -1,23 +1,28 @@
 package com.fastcampus.projectboardadmin.service;
 
+import com.fastcampus.projectboardadmin.domain.AdminAccount;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import com.fastcampus.projectboardadmin.repository.AdminAccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class AdminAccountService {
 
     private final AdminAccountRepository adminAccountRepository;
 
+    @Transactional(readOnly = true)
     public Optional<AdminAccountDto> searchUser(String username) {
-        return Optional.empty();
+        return adminAccountRepository.findById(username)
+                .map(AdminAccountDto::from);
     }
 
     public AdminAccountDto saveUser(
@@ -28,14 +33,28 @@ public class AdminAccountService {
             String nickname,
             String memo
     ) {
-        return null;
+        return AdminAccountDto.from(
+                adminAccountRepository.save(
+                AdminAccount.of(
+                        username,
+                        password,
+                        roleTypes,
+                        email,
+                        nickname,
+                        memo
+                ))
+        );
     }
 
+    @Transactional(readOnly = true)
     public List<AdminAccountDto> users() {
-        return List.of();
+        return adminAccountRepository.findAll()
+                .stream()
+                .map(AdminAccountDto::from)
+                .toList();
     }
 
     public void deleteUser(String username) {
-
+        adminAccountRepository.deleteById(username);
     }
 }

--- a/src/main/resources/templates/admin/members.html
+++ b/src/main/resources/templates/admin/members.html
@@ -27,7 +27,7 @@
 
 <!--/* 페이지 전용 스크립트 */-->
 <script src="/js/plugins/jsgrid/jsgrid.min.js"></script>
-<script>
+<script id="jsgrid-javascript">
     $(function () {
         $("#jsgrid-admin-members").jsGrid({
             height: "100%",

--- a/src/main/resources/templates/admin/members.th.xml
+++ b/src/main/resources/templates/admin/members.th.xml
@@ -3,8 +3,59 @@
     <attr sel="#layout-head" th:replace="layouts/layout-head :: common_head(~{::title}, (~{::link} ?: ~{}))" />
     <attr sel="#layout-header" th:replace="layouts/layout-header :: header" />
     <attr sel="#layout-left-aside" th:replace="layouts/layout-left-aside :: aside" />
-    <attr sel="#layout-main" th:replace="layouts/layout-main-table :: common_main_table('관리자 계정', (~{::#jsgrid-admin-members} ?: ~{}))" />
+    <attr sel="#layout-main" th:replace="layouts/layout-main-table :: common_main_table('관리자', (~{::#jsgrid-admin-members} ?: ~{}))" />
     <attr sel="#layout-right-aside" th:replace="layouts/layout-right-aside :: aside" />
     <attr sel="#layout-footer" th:replace="layouts/layout-footer :: footer" />
     <attr sel="#layout-scripts" th:replace="layouts/layout-scripts :: script" />
+
+    <attr sel="#jsgrid-javascript" th:utext='|
+    $(() => {
+      const csrfHeader = "${_csrf.headerName}";
+      const csrfToken = "${_csrf.token}";
+
+      $("#jsgrid-admin-members").jsGrid({
+        width: "100%",
+
+        autoload: true,
+        inserting: false,
+        editing: false,
+        sorting: true,
+        paging: false,
+        confirmDeleting: true,
+        deleteConfirm: "선택하신 어드민 계정을 삭제하시겠습니까?",
+
+        fields: [
+          { name: "userId", title: "유저 ID", type: "text", width: 70 },
+          { name: "nickname", title: "닉네임", type: "text", width: 60 },
+          { name: "email", title: "이메일", type: "text", width: 120 },
+          { name: "memo", title: "메모", type: "text", width: 150 },
+          { name: "roleTypes", title: "권한", type: "text", width: 100 },
+          { name: "createdBy", title: "작성자", type: "text", width: 60 },
+          { name: "createdAt", title: "작성일시", type: "text", width: 100 },
+          { type: "control" }
+        ],
+
+        controller: {
+          loadData: (filter) => {
+            return $.ajax({
+              type: "GET",
+              url: "/api/admin/members",
+              data: filter,
+              dataType: "json"
+            });
+          },
+          insertItem: $.noop,
+          updateItem: $.noop,
+          deleteItem: (item) => {
+            return $.ajax({
+              type: "DELETE",
+              url: "/api/admin/members/" + item.userId,
+              data: item,
+              beforeSend: (xhr) => xhr.setRequestHeader(csrfHeader, csrfToken)
+            });
+          },
+        }
+      });
+    });
+  |'/>
 </thlogic>

--- a/src/main/resources/templates/layouts/layout-main-table-modal.html
+++ b/src/main/resources/templates/layouts/layout-main-table-modal.html
@@ -21,9 +21,9 @@
             </article>
             <div class="modal-footer justify-content-between">
                 <button type="button" class="btn btn-default" data-dismiss="modal">닫기</button>
-<!--                <form>-->
-<!--                    <button type="submit" class="btn btn-danger">삭제</button>-->
-<!--                </form>-->
+                <form>
+                    <button type="submit" class="btn btn-danger">삭제</button>
+                </form>
             </div>
         </div>
         <!-- /.modal-content -->

--- a/src/main/resources/templates/layouts/layout-main-table-modal.th.xml
+++ b/src/main/resources/templates/layouts/layout-main-table-modal.th.xml
@@ -3,5 +3,5 @@
     <attr sel=".modal-body/pre" th:style="'white-space: pre-line'" />
 
     <!--/* 실제 url 주입은 javascript에 의해 동적으로 이루어져야 한다. th:action은 해당 form에 csrf 토큰을 자동으로 세팅하는데 사용됨. */-->
-<!--    <attr sel=".modal-footer/form" th:action="@{#}" th:method="post" />-->
+    <attr sel=".modal-footer/form" th:action="@{#}" th:method="post" />
 </thlogic>

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -23,6 +24,7 @@ class MainControllerTest {
         this.mvc = mvc;
     }
 
+    @WithMockUser(username = "tester", roles = "USER")
     @DisplayName("[View][GET] 루트 페이지 -> 게시글 고나리 페이지 Forwarding")
     @Test
     void givenNothing_whenRequestingRootView_thenForwardsToArticleManagementView() throws Exception {

--- a/src/test/java/com/fastcampus/projectboardadmin/service/AdminAccountServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/AdminAccountServiceTest.java
@@ -79,7 +79,7 @@ class AdminAccountServiceTest {
         assertThat(result)
                 .hasFieldOrPropertyWithValue("userId", admin.getUserId())
                 .hasFieldOrPropertyWithValue("userPassword", admin.getUserPassword())
-                .hasFieldOrPropertyWithValue("roleType", admin.getRoleTypes())
+                .hasFieldOrPropertyWithValue("roleTypes", admin.getRoleTypes())
                 .hasFieldOrPropertyWithValue("email", admin.getEmail())
                 .hasFieldOrPropertyWithValue("nickname", admin.getNickname())
                 .hasFieldOrPropertyWithValue("memo", admin.getMemo())

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleCommentManagementServiceTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 class ArticleCommentManagementServiceTest {
 
     // 1. 실제 API server 통신 상태 test
-//    @Disabled("실재 API 호출 결과 관찰이 필요할 경우 활성화")
+    @Disabled("실재 API 호출 결과 관찰이 필요할 경우 활성화")
     @DisplayName("실제 API 호출 TEST")
     @SpringBootTest
     @Nested

--- a/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/ArticleManagementServiceTest.java
@@ -42,7 +42,7 @@ class ArticleManagementServiceTest {
     // -> data source 가 외부(게시글 프로젝트 내 DB)에 존재하기 때문
 
     // 1. 실제 API 로부터 받은 data 를 사용하는 test
-//    @Disabled("실제 API 호출 결과 관찰용이므로 평상시에는 비활성화")
+    @Disabled("실제 API 호출 결과 관찰용이므로 평상시에는 비활성화")
     @DisplayName("실제 API 호출 TEST")
     @SpringBootTest
     @Nested

--- a/src/test/java/com/fastcampus/projectboardadmin/service/UserAccountManagementServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/service/UserAccountManagementServiceTest.java
@@ -33,7 +33,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 class UserAccountManagementServiceTest {
 
     // 1. 실제 API server 통신 상태 test
-//    @Disabled("실제 API 호출 결과 확인을 위한 test 이므로 logic test 상황에서는 비활성화")
+    @Disabled("실제 API 호출 결과 확인을 위한 test 이므로 logic test 상황에서는 비활성화")
     @DisplayName("실제 API 호출 Test")
     @SpringBootTest
     @Nested
@@ -121,7 +121,7 @@ class UserAccountManagementServiceTest {
             UserAccountDto expectedUser = createUserAccountDto(userId, "Uno");
 
             server
-                    .expect(requestTo(projectProperty.board().url() + "/api/userAccounts/" + userId + "?projection=withUserAccount"))
+                    .expect(requestTo(projectProperty.board().url() + "/api/userAccounts/" + userId))
                     .andRespond(withSuccess(
                             mapper.writeValueAsString(expectedUser),
                             MediaType.APPLICATION_JSON


### PR DESCRIPTION
 * 로그인 page 의 경우 기존 Spring Security 에서 제공하는 view 를 그대로 사용
 * 관리자 계정 관리 페이지 view, controller, service, test 구현
 * 기존 문제가 있었던 modal - `삭제` form 부분이 (아마도) security 를 정상적으로 활성화 하여, 문제가 사라졌으므로, 해당 사항을 활성화 시킴.  

This closes #28 