### PR TITLE
[관리자] Admin 부가 기능 - 방문자 수 집계

### DIFF
--- a/src/main/java/com/fastcampus/projectboardadmin/controller/advice/VisitCounterControllerAdvice.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/controller/advice/VisitCounterControllerAdvice.java
@@ -1,0 +1,22 @@
+package com.fastcampus.projectboardadmin.controller.advice;
+
+
+import com.fastcampus.projectboardadmin.service.VisitCounterService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+
+// 모든 view Endpoint 에 해당 attribute 를 공통으로 내려줌  (전역 변수처럼 사용???)
+@RequiredArgsConstructor
+@ControllerAdvice
+public class VisitCounterControllerAdvice {
+
+    private final VisitCounterService visitCounterService;
+
+
+    @ModelAttribute("visitCount")
+    public Long visitCount() {
+        return visitCounterService.visitCount();
+    }
+}

--- a/src/main/java/com/fastcampus/projectboardadmin/service/VisitCounterService.java
+++ b/src/main/java/com/fastcampus/projectboardadmin/service/VisitCounterService.java
@@ -1,0 +1,49 @@
+package com.fastcampus.projectboardadmin.service;
+
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class VisitCounterService {
+
+    private final MeterRegistry meterRegistry; //  Java 애플리케이션의 성능 메트릭을 측정하고 모니터링 툴과 연동하기 위한 라이브러리 https://micrometer.io/
+
+    // localhost:8081/actuator/metrics/http.server.requests
+    // -> "tag": "uri", "value": [view page, actuator, rest api 작업 등을 수행하기 위해 정의된 많은 uri 에 대한 list]
+    //     uri 리스트 중에서, view pages ("/admin/members", "/management/articles", "/management/article-comments", "/management/userAccounts")
+    //     위 네곳 만 filtering 해서 보갰다.
+    private static final List<String> viewEndpoints = List.of(
+            "/management/articles",
+            "/management/article-comments",
+            "/management/user-accounts",
+            "/admin/members"
+    );
+    public long visitCount() {
+
+        long sum;
+
+        // 최초 application 을 실행했을 때, 아래 get("http.server.requests") 의 값은 존재하지 않아
+        // 이때 error 가 발생한다.
+        // 이를 해결하기 위해 MeterNotFoundExpection error catch 가 필요하다.
+        // http://localhost:8081/actuator/metrics  - "names" -> http.server.requests
+        try {
+            sum = meterRegistry.get("http.server.requests")
+                    .timers()
+                    .stream()
+                    .filter(timer -> viewEndpoints.contains(timer.getId().getTag("uri")))
+                    .mapToLong(Timer::count)
+                    .sum();
+        } catch (MeterNotFoundException e) {
+            sum = 0L;
+        }
+
+        return sum;
+    }
+}

--- a/src/main/resources/templates/layouts/layout-left-aside.html
+++ b/src/main/resources/templates/layouts/layout-left-aside.html
@@ -83,6 +83,15 @@
                     </ul>
                 </li>
             </ul>
+            <div class="small-box bg-info">
+                <div class="inner">
+                    <h3 id="visit-count">0</h3>
+                    <p>방문 횟수</p>
+                </div>
+                <div class="icon">
+                    <i class="fas fa-chart-pie"></i>
+                </div>
+            </div>
         </nav>
         <!--/* /.sidebar-menu */-->
     </div>

--- a/src/main/resources/templates/layouts/layout-left-aside.th.xml
+++ b/src/main/resources/templates/layouts/layout-left-aside.th.xml
@@ -24,4 +24,6 @@
             th:href="@{/admin/members}"
             th:classappend="${#request.requestURI.equals('/admin/members')} ? 'active'"
     />
+
+    <attr sel="#visit-count" th:text="${visitCount}" />
 </thlogic>

--- a/src/test/java/com/fastcampus/projectboardadmin/config/GlobalControllerConfig.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/config/GlobalControllerConfig.java
@@ -1,0 +1,19 @@
+package com.fastcampus.projectboardadmin.config;
+
+import com.fastcampus.projectboardadmin.service.VisitCounterService;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import static org.mockito.BDDMockito.given;
+
+@TestConfiguration
+public class GlobalControllerConfig {
+
+    @MockBean private VisitCounterService visitAccountService;
+
+    @BeforeTestMethod
+    public void securitySetup() {
+        given(visitAccountService.visitCount()).willReturn(0L);
+    }
+}

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/AdminAccountControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/AdminAccountControllerTest.java
@@ -1,7 +1,7 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.config.GlobalControllerConfig;
 import com.fastcampus.projectboardadmin.config.SecurityConfig;
-import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import com.fastcampus.projectboardadmin.domain.constant.RoleType;
 import com.fastcampus.projectboardadmin.dto.AdminAccountDto;
 import com.fastcampus.projectboardadmin.service.AdminAccountService;
@@ -34,7 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 // (Error: Duplicate mock definition)
 // 따라서 실제 application class (SecurityConfig.class) 를 사용하고, 관련 인증 처리를 모두 해주어야 한다.
 @DisplayName("View Controller - Admin Account")
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, GlobalControllerConfig.class})
 @WebMvcTest(AdminAccountController.class)
 class AdminAccountControllerTest {
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleCommentManagementControllerTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.config.GlobalControllerConfig;
 import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import com.fastcampus.projectboardadmin.dto.ArticleCommentDto;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
@@ -24,7 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View Controller - 댓글 관리")
-@Import(TestSecurityConfig.class)
+@Import({TestSecurityConfig.class, GlobalControllerConfig.class})
 @WebMvcTest(ArticleCommentManagementController.class)
 class ArticleCommentManagementControllerTest {
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/ArticleManagementControllerTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.config.GlobalControllerConfig;
 import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import com.fastcampus.projectboardadmin.dto.ArticleDto;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
@@ -24,7 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View Controller - 게시글 관리")
-@Import(TestSecurityConfig.class)
+@Import({TestSecurityConfig.class, GlobalControllerConfig.class})
 @WebMvcTest(ArticleManagementController.class)
 class ArticleManagementControllerTest {
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/MainControllerTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.config.GlobalControllerConfig;
 import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @DisplayName("View Root Controller")
-@Import(TestSecurityConfig.class)
+@Import({TestSecurityConfig.class, GlobalControllerConfig.class})
 @WebMvcTest(MainController.class)
 class MainControllerTest {
 

--- a/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
+++ b/src/test/java/com/fastcampus/projectboardadmin/controller/UserAccountManagementControllerTest.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboardadmin.controller;
 
+import com.fastcampus.projectboardadmin.config.GlobalControllerConfig;
 import com.fastcampus.projectboardadmin.config.TestSecurityConfig;
 import com.fastcampus.projectboardadmin.dto.UserAccountDto;
 import com.fastcampus.projectboardadmin.service.UserAccountManagementService;
@@ -23,7 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 @DisplayName("View Controller - 회원 정보 관리")
-@Import(TestSecurityConfig.class)
+@Import({TestSecurityConfig.class, GlobalControllerConfig.class})
 @WebMvcTest(UserAccountManagementController.class)
 class UserAccountManagementControllerTest {
 


### PR DESCRIPTION
방문자 수 계산 및 표시 관련 학습을 위해, 관리자 application 에서는 사실 불필요하지만, 관련 기능을 넣어준다.
학습을 위해, view 의 각 페이지를 열 때마다 전체 방문자 수가 증가하도록 구현하였다.


VisitCounterControllerAdvice
 - @ControllerAdvice annotation 을 적용하여, controller component 들이 실행할 때, 공통적으로 적용할 수 있는 component 를 생성해 준다. 주로  client 의 잘못된 요청에 대한 error 처리  @ExceptionHandler 나 모든 view 에 대한 model attribute 를 적용하기 위해 사용된다. 따라서 각 page 에 모두 `방문횟수` 를 반영하기 위한 model attribute 를 정의 하고, 이와 관련된 business logic 을 구현할 VisitCounterService method 를 명시해 준다.

VisitCounterService
 - 현 구현에서 방문자 수에 대한 영속성 부여 작업은 없이 browser session 이 유지되는 내에서의  방문횟수만 기록한다.
 - 방문횟수는 spring actuator 에서 제공하는 micrometer 라이브러리 기능을 사용한다.  이중 MeterRegistry class 를 사용하면 java applicatoin 의 성능 metrics 를 측정할 수 있으며,  application 으로의 요청 횟수(http.server.reqeuests) 중 작성자가 의도한 page view 요청 endpoint 들로 filtering 하여 앞에서 설계한 대로 방문횟수를 count 할 수 있다.
 - 다만, 최초 appilcation 을 실행했을 때, 해당 방문횟수는 기록될 수 없으므로 error 를 발생시킨다. 따라서 이에 대한 error catch 처리를 함께 넣어준다.

GlobalControllerConfig
 - @ControllerAdvice 적용 component 가 추가됨에 따라,  모든 Test component 들도 해당 bean 생성이 영향을 받게 된다. 따라서 test 에서는 해당 bean 생성을 우회해서 직접 해당 service 에 접근하여, test 에 필요한 결과 값을 받을 있도록 별도의 설정이 필요하다.   따라서 해당 내용을 구현해줌.

모든 controlleTest
 -   VisitCounterControllerAdvice  component 의 영향은 없지만, 필요한  VisitCounterSerivce 결과를 받아 올 수 있는 GlobalControllerConfig 를 import 하여 test 진행에 문제가 없도록 재설정 해준다.

This closes #61 
